### PR TITLE
Condensed repr for attrs classes

### DIFF
--- a/requests_cache/_utils.py
+++ b/requests_cache/_utils.py
@@ -48,6 +48,9 @@ def get_placeholder_class(original_exception: Exception = None):
         def dumps(self, *args, **kwargs):
             _log_error()
 
+        def loads(self, *args, **kwargs):
+            _log_error()
+
     return Placeholder
 
 

--- a/requests_cache/models/base.py
+++ b/requests_cache/models/base.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import List
 
 from attr import Factory
 
@@ -10,7 +11,8 @@ class RichMixin:
     * Inform rich about all default values so they will be excluded from output
     * Handle default value factories
     * Stringify datetime objects
-    * Does not currently handle positional-only args (since we don't currently have any)
+    * Does not handle positional-only args (since we don't currently have any)
+    * Add a base repr that excludes default values even if rich isn't installed
     """
 
     def __rich_repr__(self):
@@ -20,3 +22,12 @@ class RichMixin:
             value = getattr(self, a.name)
             value = str(value) if isinstance(value, datetime) else value
             yield a.name, value, default
+
+    def __repr__(self):
+        tokens: List[str] = []
+        for arg in self.__rich_repr__():
+            key, value, default = arg
+            tokens.append(f'{key}={value!r}' if value != default else None)
+
+        repr_attrs = ', '.join([t for t in tokens if t])
+        return f'{self.__class__.__name__}({repr_attrs})'

--- a/requests_cache/models/raw_response.py
+++ b/requests_cache/models/raw_response.py
@@ -15,8 +15,8 @@ from . import RichMixin
 logger = getLogger(__name__)
 
 
-@define(auto_attribs=False, slots=False)
-class CachedHTTPResponse(HTTPResponse, RichMixin):
+@define(auto_attribs=False, repr=False, slots=False)
+class CachedHTTPResponse(RichMixin, HTTPResponse):
     """A serializable dataclass that emulates :py:class:`~urllib3.response.HTTPResponse`.
     Supports streaming requests and generator usage.
 

--- a/requests_cache/models/request.py
+++ b/requests_cache/models/request.py
@@ -12,7 +12,7 @@ from . import RichMixin
 logger = getLogger(__name__)
 
 
-@define(auto_attribs=False)
+@define(repr=False)
 class CachedRequest(RichMixin):
     """A serializable dataclass that emulates :py:class:`requests.PreparedResponse`"""
 

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -22,7 +22,7 @@ DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S %Z'  # Format used for __str__ only
 logger = getLogger(__name__)
 
 
-@define(auto_attribs=False, slots=False)
+@define(auto_attribs=False, repr=False, slots=False)
 class BaseResponse(Response):
     """Wrapper class for responses returned by :py:class:`.CachedSession`. This mainly exists to
     provide type hints for extra cache-related attributes that are added to non-cached responses.
@@ -58,8 +58,8 @@ class OriginalResponse(BaseResponse):
         return response
 
 
-@define(auto_attribs=False, slots=False)
-class CachedResponse(BaseResponse, RichMixin):
+@define(auto_attribs=False, repr=False, slots=False)
+class CachedResponse(RichMixin, BaseResponse):
     """A class that emulates :py:class:`requests.Response`, optimized for serialization"""
 
     _content: bytes = field(default=None)

--- a/requests_cache/policy/actions.py
+++ b/requests_cache/policy/actions.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 logger = getLogger(__name__)
 
 
-@define
+@define(repr=False)
 class CacheActions(RichMixin):
     """Translates cache settings and headers into specific actions to take for a given cache item.
      The resulting actions are then handled in :py:meth:`CachedSession.send`.
@@ -48,7 +48,6 @@ class CacheActions(RichMixin):
     """
 
     # Outputs
-    # TODO: Besides skip read/write, will there always be only one action? Should these be an enum instead?
     cache_key: str = field(default=None, repr=False)
     error_504: bool = field(default=False)
     expire_after: ExpirationTime = field(default=None)

--- a/requests_cache/policy/directives.py
+++ b/requests_cache/policy/directives.py
@@ -9,7 +9,7 @@ from ..models import RichMixin
 from . import HeaderDict, get_expiration_seconds
 
 
-@define
+@define(repr=False)
 class CacheDirectives(RichMixin):
     """Parses Cache-Control directives and other relevant cache settings from either request or
     response headers

--- a/requests_cache/policy/settings.py
+++ b/requests_cache/policy/settings.py
@@ -15,7 +15,7 @@ DEFAULT_STATUS_CODES = (200,)
 DEFAULT_IGNORED_PARAMS = ('Authorization', 'X-API-KEY', 'access_token', 'api_key')
 
 
-@define
+@define(repr=False)
 class CacheSettings(RichMixin):
     """Class used internally to store settings that affect caching behavior. This allows settings
     to be used across multiple modules, but exposed to the user in a single property

--- a/tests/integration/test_compat.py
+++ b/tests/integration/test_compat.py
@@ -3,11 +3,11 @@ from shutil import copyfile
 import pytest
 
 from requests_cache import CachedSession
-from tests.conftest import HTTPBIN_FORMATS, SAMPLE_CACHE_FILES
+from tests.conftest import HTTPBIN_FORMATS, SAMPLE_CACHE_FILES, httpbin
 
 
 # TODO: Debug why this sometimes fails (mostly just on GitHub Actions)
-@pytest.mark.flaky(reruns=3)
+# @pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize('db_path', SAMPLE_CACHE_FILES)
 def test_version_upgrade(db_path, tempfile_path):
     """Load SQLite cache files created with older versions of requests-cache.
@@ -21,5 +21,5 @@ def test_version_upgrade(db_path, tempfile_path):
     session = CachedSession(tempfile_path)
 
     for response_format in HTTPBIN_FORMATS:
-        session.get(f'https://httpbin.org/{response_format}').from_cache
-        assert session.get(f'https://httpbin.org/{response_format}').from_cache is True
+        session.get(httpbin(response_format)).from_cache
+        assert session.get(httpbin(response_format)).from_cache is True

--- a/tests/unit/models/test_base.py
+++ b/tests/unit/models/test_base.py
@@ -24,3 +24,9 @@ def test_rich_mixin():
         ('int_attr', 1, None),
         ('list_attr', ['a', 'b'], []),
     ]
+
+
+def test_repr():
+    """Test that regular __repr__ excludes default values"""
+    assert repr(DemoModel() == 'DemoModel()')
+    assert repr(DemoModel(str_attr='str') == "DemoModel(str_attr='str')")

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -74,6 +74,8 @@ def test_optional_dependencies():
         for obj in [bson_serializer, yaml_serializer]:
             with pytest.raises(ImportError):
                 obj.dumps('')
+            with pytest.raises(ImportError):
+                obj.loads('')
 
         with pytest.raises(ImportError):
             safe_pickle_serializer('')


### PR DESCRIPTION
Instances of some of these classes are fairly useful to have in debug logs, especially `CacheActions` to show exactly what criteria were used to read or write something from the cache. It gets a bit verbose, though.

I previously made some changes for better output when logged with `rich`. This does the same thing without `rich` installed, and condenses the output to exclude any default values. So instead of:
```python
>>> repr(CacheActions(resend_async=True))
'CacheActions(error_504=False, expire_after=None, send_request=False, resend_request=False, resend_async=True, skip_read=False, skip_write=False)'
```

It now looks like:
```python
>>> repr(CacheActions(resend_async=True))
'CacheActions(resend_async=True)'
```
