### PR TITLE
Split up remove_expired_reponses() into more granular methods and arguments

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -55,6 +55,13 @@
 * Always skip both cache read and write for requests excluded by `allowable_methods` (previously only skipped write)
 * Ignore and redact common authentication headers and request parameters by default. This provides some default recommended values for `ignored_parameters`, to avoid accidentally storing common credentials (e.g., OAuth tokens) in the cache. This will have no effect if you are already setting `ignored_parameters`.
 
+**Other features:**
+* Split existing features of `BaseCache.remove_expired_responses()` into multiple methods and arguments:
+  * Add `BaseCache.remove()` method with `expired` and `invalid` arguments
+  * Add `BaseCache.reset_expiration()` method to reset expiration for existing responses
+* Add `older_than` argument to `BaseCache.remove()` to remove responses older than a given value
+* Add `BaseCache.items()` method
+
 **Type hints:**
 * Add `OriginalResponse` type, which adds type hints to `requests.Response` objects for extra attributes added by requests-cache:
   * `cache_key`
@@ -68,6 +75,9 @@
 
 **Dependencies:**
 * Replace `appdirs` with `platformdirs`
+
+**Deprecations:**
+* `BaseCache.remove_expired_responses()` and `CachedSession.remove_expired_responses()` are deprecated in favor of `BaseCache.remove()`
 
 **Breaking changes:**
 

--- a/docs/user_guide/expiration.md
+++ b/docs/user_guide/expiration.md
@@ -150,9 +150,9 @@ For better read performance, expired responses won't be removed immediately, but
 (or replaced) the next time they are requested.
 
 To manually clear all expired responses, use
-{py:meth}`.CachedSession.remove_expired_responses`:
+{py:meth}`.BaseCache.remove`:
 ```python
->>> session.remove_expired_responses()
+>>> session.cache.remove(expired=True)
 ```
 
 Or, if you are using {py:func}`.install_cache`:
@@ -162,14 +162,14 @@ Or, if you are using {py:func}`.install_cache`:
 
 You can also remove responses older than a certain time:
 ```python
-# Remove expired responses *and* responses older than 7 days
-remove_expired_responses(older_than=timedelta(days=7))
+# Remove responses older than 7 days
+session.cache.remove(older_than=timedelta(days=7))
 ```
 
 Or apply a new expiration value to previously cached responses:
 ```python
 # Reset expiration for all responses to 30 days from now
->>> session.remove_expired_responses(expire_after=timedelta(days=30))
+>>> session.cache.reset_expiration(timedelta(days=30))
 ```
 
 (ttl)=

--- a/docs/user_guide/inspection.md
+++ b/docs/user_guide/inspection.md
@@ -70,10 +70,10 @@ combined keys and responses.
 >>> print(list(session.cache.keys()))
 ```
 
-Both methods also take a `check_expiry` argument to exclude expired responses:
+Both methods also take a `include_expired` argument. Set to `False` to exclude expired responses:
 ```python
 >>> print('All unexpired responses:')
->>> for response in session.cache.values(check_expiry=True):
+>>> for response in session.cache.values(include_expired=False):
 >>>     print(response)
 ```
 
@@ -81,5 +81,5 @@ Similarly, you can get a count of responses with {py:meth}`.BaseCache.response_c
 exclude expired responses:
 ```python
 >>> print(f'Total responses: {session.cache.response_count()}')
->>> print(f'Unexpired responses: {session.cache.response_count(check_expiry=True)}')
+>>> print(f'Unexpired responses: {session.cache.response_count(include_expired=False)}')
 ```

--- a/examples/generate_test_db.py
+++ b/examples/generate_test_db.py
@@ -86,13 +86,13 @@ def get_randomized_response(i=0):
     return new_response
 
 
-def remove_expired_responses(expire_after=None):
+def remove_expired_responses():
     logger.setLevel('DEBUG')
     session = CachedSession(CACHE_NAME)
     total_responses = len(session.cache.responses)
 
     start = time()
-    session.remove_expired_responses(expire_after=expire_after)
+    session.cache.remove(expired=True)
     elapsed = time() - start
     n_removed = total_responses - len(session.cache.responses)
     logger.info(
@@ -121,6 +121,3 @@ if __name__ == '__main__':
 
     # Remove some responses (with randomized expiration)
     # remove_expired_responses()
-
-    # Expire and remove all responses
-    # remove_expired_responses(expire_after=1)

--- a/requests_cache/backends/filesystem.py
+++ b/requests_cache/backends/filesystem.py
@@ -60,9 +60,9 @@ class FileCache(BaseCache):
         self.responses.clear()
         self.redirects.init_db()
 
-    def remove_expired_responses(self, *args, **kwargs):
+    def remove(self, *args, **kwargs):
         with self.responses._lock:
-            return super().remove_expired_responses(*args, **kwargs)
+            return super().remove(*args, **kwargs)
 
 
 class FileDict(BaseStorage):

--- a/requests_cache/backends/gridfs.py
+++ b/requests_cache/backends/gridfs.py
@@ -38,9 +38,9 @@ class GridFSCache(BaseCache):
             **kwargs
         )
 
-    def remove_expired_responses(self, *args, **kwargs):
+    def remove(self, *args, **kwargs):
         with self.responses._lock:
-            return super().remove_expired_responses(*args, **kwargs)
+            return super().remove(*args, **kwargs)
 
 
 class GridFSDict(BaseStorage):

--- a/requests_cache/backends/sqlite.py
+++ b/requests_cache/backends/sqlite.py
@@ -75,12 +75,12 @@ class SQLiteCache(BaseCache):
             self.responses.init_db()
             self.redirects.init_db()
 
-    def remove_expired_responses(
-        self, expire_after: ExpirationTime = None, older_than: ExpirationTime = None
+    def remove(
+        self, expired: bool = False, invalid: bool = False, older_than: ExpirationTime = None
     ):
-        if expire_after is not None or older_than is not None:
+        if invalid or older_than is not None:
             with self.responses._lock, self.redirects._lock:
-                return super().remove_expired_responses(expire_after, older_than)
+                return super().remove(expired=expired, invalid=invalid, older_than=older_than)
         else:
             self.responses.clear_expired()
             self.remove_invalid_redirects()

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -160,8 +160,8 @@ class CachedResponse(RichMixin, BaseResponse):
         """Returns a PreparedRequest for the next request in a redirect chain, if there is one."""
         return self._next.prepare() if self._next else None
 
-    def reset_expiration(self, expire_after: ExpirationTime) -> bool:
-        """Set a new expiration for this response, and determine if it is now expired"""
+    def reset_expiration(self, expire_after: ExpirationTime):
+        """Set a new expiration for this response"""
         self.expires = get_expiration_datetime(expire_after)
         return self.is_expired
 

--- a/requests_cache/patcher.py
+++ b/requests_cache/patcher.py
@@ -14,7 +14,6 @@ from typing import Optional, Type
 import requests
 
 from .backends import BackendSpecifier, BaseCache, init_backend
-from .policy import ExpirationTime
 from .session import CachedSession, OriginalSession
 
 logger = getLogger(__name__)
@@ -107,15 +106,11 @@ def clear():
         get_cache().clear()
 
 
-def remove_expired_responses(expire_after: ExpirationTime = None):
-    """Remove expired responses from the cache, and optionally reset expiration
-
-    Args:
-        expire_after: A new expiration time to set on existing cache items
-    """
+def remove_expired_responses():
+    """Remove expired and invalid responses from the cache"""
     session = requests.Session()
     if isinstance(session, CachedSession):
-        session.remove_expired_responses(expire_after)
+        session.cache.remove(expired=True)
 
 
 def _patch_session_factory(session_factory: Type[OriginalSession] = CachedSession):

--- a/requests_cache/session.py
+++ b/requests_cache/session.py
@@ -307,17 +307,12 @@ class CacheMixin(MIXIN_BASE):
         super().close()
         self.cache.close()
 
-    def remove_expired_responses(
-        self, expire_after: ExpirationTime = None, older_than: ExpirationTime = None
-    ):
-        """Remove expired and invalid responses from the cache, and optionally reset expiration
+    def remove_expired_responses(self):
+        """Remove expired and invalid responses from the cache
 
-        Args:
-            expire_after: A new expiration value to set on existing cache items (relative to the
-                current time)
-            older_than: Remove all cache items older than this value
+        **Deprecated:** Use ``session.cache.remove(expired=True)`` instead.
         """
-        self.cache.remove_expired_responses(expire_after, older_than)
+        self.cache.remove(expired=True, invalid=True)
 
     def __repr__(self):
         return f'<CachedSession(cache={repr(self.cache)}, settings={self.settings})>'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from functools import wraps
 from importlib import import_module
 from logging import basicConfig, getLogger
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -268,3 +268,7 @@ def skip_missing_deps(module_name: str) -> pytest.Mark:
     return pytest.mark.skipif(
         not is_installed(module_name), reason=f'{module_name} is not installed'
     )
+
+
+# Some tests must disable url normalization to retain the custom `http+mock://` protocol
+patch_normalize_url = patch('requests_cache.cache_keys.normalize_url', side_effect=lambda x, y: x)

--- a/tests/unit/test_base_cache.py
+++ b/tests/unit/test_base_cache.py
@@ -1,14 +1,24 @@
 """BaseCache tests that use mocked responses only"""
 from datetime import datetime, timedelta
+from logging import getLogger
+from pickle import PickleError
+from time import sleep
 from unittest.mock import patch
 
 import pytest
 
-from requests_cache import CachedResponse
 from requests_cache.backends import BaseCache, SQLiteDict
-from tests.conftest import MOCKED_URL, MOCKED_URL_HTTPS, MOCKED_URL_JSON, MOCKED_URL_REDIRECT
+from requests_cache.models import CachedRequest, CachedResponse
+from tests.conftest import (
+    MOCKED_URL,
+    MOCKED_URL_HTTPS,
+    MOCKED_URL_JSON,
+    MOCKED_URL_REDIRECT,
+    patch_normalize_url,
+)
 
 YESTERDAY = datetime.utcnow() - timedelta(days=1)
+logger = getLogger(__name__)
 
 
 class TimeBomb:
@@ -40,17 +50,6 @@ def test_keys(mock_session):
     assert set(mock_session.cache.keys()) == all_keys
 
 
-def test_update(mock_session):
-    src_cache = BaseCache()
-    for i in range(20):
-        src_cache.responses[f'key_{i}'] = f'value_{i}'
-        src_cache.redirects[f'key_{i}'] = f'value_{i}'
-
-    mock_session.cache.update(src_cache)
-    assert len(mock_session.cache.responses) == 20
-    assert len(mock_session.cache.redirects) == 20
-
-
 def test_values(mock_session):
     for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]:
         mock_session.get(url)
@@ -60,23 +59,23 @@ def test_values(mock_session):
     assert all([isinstance(response, CachedResponse) for response in responses])
 
 
-@pytest.mark.parametrize('check_expiry, expected_count', [(True, 1), (False, 2)])
-def test_values__with_invalid_responses(check_expiry, expected_count, mock_session):
+@pytest.mark.parametrize('include_expired, expected_count', [(False, 1), (True, 2)])
+def test_values__with_invalid_responses(include_expired, expected_count, mock_session):
     """values() should always exclude invalid responses, and optionally exclude expired responses"""
     responses = [mock_session.get(url) for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]]
     responses[1] = AttributeError
     responses[2] = CachedResponse(expires=YESTERDAY, url='test')
 
     with patch.object(SQLiteDict, '__getitem__', side_effect=responses):
-        values = mock_session.cache.values(check_expiry=check_expiry)
+        values = mock_session.cache.values(include_expired=include_expired)
         assert len(list(values)) == expected_count
 
     # The invalid response should be skipped, but remain in the cache for now
     assert len(mock_session.cache.responses.keys()) == 3
 
 
-@pytest.mark.parametrize('check_expiry, expected_count', [(True, 2), (False, 3)])
-def test_response_count(check_expiry, expected_count, mock_session):
+@pytest.mark.parametrize('include_expired, expected_count', [(False, 2), (True, 3)])
+def test_response_count(include_expired, expected_count, mock_session):
     """response_count() should always exclude invalid responses, and optionally exclude expired
     and invalid responses"""
     mock_session.get(MOCKED_URL)
@@ -84,7 +83,144 @@ def test_response_count(check_expiry, expected_count, mock_session):
 
     mock_session.cache.responses['expired_response'] = CachedResponse(expires=YESTERDAY)
     mock_session.cache.responses['invalid_response'] = TimeBomb()
-    assert mock_session.cache.response_count(check_expiry=check_expiry) == expected_count
+    assert mock_session.cache.response_count(include_expired=include_expired) == expected_count
+
+
+@patch_normalize_url
+def test_remove__expired(mock_normalize_url, mock_session):
+    """Test BaseCache.remove_expired_responses()"""
+    unexpired_url = f'{MOCKED_URL}?x=1'
+    mock_session.mock_adapter.register_uri(
+        'GET', unexpired_url, status_code=200, text='mock response'
+    )
+    mock_session.settings.expire_after = 1
+    mock_session.get(MOCKED_URL)
+    mock_session.get(MOCKED_URL_JSON)
+    sleep(1)
+    mock_session.get(unexpired_url)
+
+    # At this point we should have 1 unexpired response and 2 expired responses
+    assert len(mock_session.cache.responses) == 3
+
+    # Use the generic BaseCache implementation, not the SQLite-specific one
+    BaseCache.remove(mock_session.cache, expired=True)
+    assert len(mock_session.cache.responses) == 1
+    cached_response = list(mock_session.cache.responses.values())[0]
+    assert cached_response.url == unexpired_url
+
+    # Now the last response should be expired as well
+    sleep(1)
+    BaseCache.remove(mock_session.cache, expired=True)
+    assert len(mock_session.cache.responses) == 0
+
+
+def test_remove__error(mock_session):
+    # Start with two cached responses, one of which will raise an error
+    response_1 = mock_session.get(MOCKED_URL)
+    response_2 = mock_session.get(MOCKED_URL_JSON)
+
+    def error_on_key(key):
+        if key == response_2.cache_key:
+            raise PickleError
+        return CachedResponse.from_response(response_1)
+
+    # Use the generic BaseCache implementation, not the SQLite-specific one
+    with patch.object(SQLiteDict, '__getitem__', side_effect=error_on_key):
+        BaseCache.remove(mock_session.cache, expired=True)
+
+    assert len(mock_session.cache.responses) == 1
+    assert mock_session.get(MOCKED_URL).from_cache is True
+    assert mock_session.get(MOCKED_URL_JSON).from_cache is False
+
+
+def test_remove__expired__per_request(mock_session):
+    # Cache 3 responses with different expiration times
+    second_url = f'{MOCKED_URL}/endpoint_2'
+    third_url = f'{MOCKED_URL}/endpoint_3'
+    mock_session.mock_adapter.register_uri('GET', second_url, status_code=200)
+    mock_session.mock_adapter.register_uri('GET', third_url, status_code=200)
+    mock_session.get(MOCKED_URL)
+    mock_session.get(second_url, expire_after=2)
+    mock_session.get(third_url, expire_after=4)
+
+    # All 3 responses should still be cached
+    mock_session.cache.remove(expired=True)
+    for response in mock_session.cache.responses.values():
+        logger.info(f'Expires in {response.expires_delta} seconds')
+    assert len(mock_session.cache.responses) == 3
+
+    # One should be expired after 2s, and another should be expired after 4s
+    sleep(2)
+    mock_session.cache.remove(expired=True)
+    assert len(mock_session.cache.responses) == 2
+    sleep(2)
+    mock_session.cache.remove(expired=True)
+    assert len(mock_session.cache.responses) == 1
+
+
+def test_remove__older_than(mock_session):
+    # Cache 4 responses with different creation times
+    response_0 = CachedResponse(request=CachedRequest(method='GET', url='https://test.com/test_0'))
+    mock_session.cache.save_response(response_0)
+    response_1 = CachedResponse(request=CachedRequest(method='GET', url='https://test.com/test_1'))
+    response_1.created_at -= timedelta(seconds=1)
+    mock_session.cache.save_response(response_1)
+    response_2 = CachedResponse(request=CachedRequest(method='GET', url='https://test.com/test_2'))
+    response_2.created_at -= timedelta(seconds=2)
+    mock_session.cache.save_response(response_2)
+    response_3 = CachedResponse(request=CachedRequest(method='GET', url='https://test.com/test_3'))
+    response_3.created_at -= timedelta(seconds=3)
+    mock_session.cache.save_response(response_3)
+
+    # Incrementally remove responses older than 3, 2, and 1 seconds
+    assert len(mock_session.cache.responses) == 4
+    mock_session.cache.remove(older_than=timedelta(seconds=3))
+    assert len(mock_session.cache.responses) == 3
+    mock_session.cache.remove(older_than=timedelta(seconds=2))
+    assert len(mock_session.cache.responses) == 2
+    mock_session.cache.remove(older_than=timedelta(seconds=1))
+    assert len(mock_session.cache.responses) == 1
+
+    # Remove the last response after it's 1 second old
+    sleep(1)
+    mock_session.cache.remove(older_than=timedelta(seconds=1))
+    assert len(mock_session.cache.responses) == 0
+
+
+def test_remove_expired_responses(mock_session):
+    """Test for backwards-compatibility"""
+    with patch.object(mock_session.cache, 'remove') as mock_remove, patch.object(
+        mock_session.cache, 'reset_expiration'
+    ) as mock_reset:
+        mock_session.cache.remove_expired_responses(expire_after=1)
+        mock_remove.assert_called_once_with(expired=True, invalid=True)
+        mock_reset.assert_called_once_with(1)
+
+        mock_session.cache.remove_expired_responses()
+        assert mock_remove.call_count == 2 and mock_reset.call_count == 1
+
+
+def test_reset_expiration__extend_expiration(mock_session):
+    # Start with an expired response
+    mock_session.settings.expire_after = datetime.utcnow() - timedelta(seconds=0.01)
+    mock_session.get(MOCKED_URL)
+
+    # Set expiration in the future
+    mock_session.cache.reset_expiration(datetime.utcnow() + timedelta(seconds=1))
+    assert len(mock_session.cache.responses) == 1
+    response = mock_session.get(MOCKED_URL)
+    assert response.is_expired is False and response.from_cache is True
+
+
+def test_reset_expiration__shorten_expiration(mock_session):
+    # Start with a non-expired response
+    mock_session.settings.expire_after = datetime.utcnow() + timedelta(seconds=1)
+    mock_session.get(MOCKED_URL)
+
+    # Set expiration in the past
+    mock_session.cache.reset_expiration(datetime.utcnow() - timedelta(seconds=0.01))
+    response = mock_session.get(MOCKED_URL)
+    assert response.is_expired is False and response.from_cache is False
 
 
 def test_clear(mock_session):
@@ -147,7 +283,18 @@ def test_delete_urls(mock_session):
         assert not mock_session.cache.has_url(MOCKED_URL_REDIRECT)
 
 
-def test_save_response_manual(mock_session):
+def test_save_response__manual(mock_session):
     response = mock_session.get(MOCKED_URL)
     mock_session.cache.clear()
     mock_session.cache.save_response(response)
+
+
+def test_update(mock_session):
+    src_cache = BaseCache()
+    for i in range(20):
+        src_cache.responses[f'key_{i}'] = f'value_{i}'
+        src_cache.redirects[f'key_{i}'] = f'value_{i}'
+
+    mock_session.cache.update(src_cache)
+    assert len(mock_session.cache.responses) == 20
+    assert len(mock_session.cache.redirects) == 20

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -81,15 +81,15 @@ def test_is_installed():
     assert requests_cache.is_installed() is False
 
 
-@patch.object(BaseCache, 'remove_expired_responses')
-def test_remove_expired_responses(remove_expired_responses):
+@patch.object(BaseCache, 'remove')
+def test_remove_expired_responses(mock_remove):
     requests_cache.install_cache(backend='memory', expire_after=360)
     requests_cache.remove_expired_responses()
-    assert remove_expired_responses.called is True
+    assert mock_remove.called is True
     requests_cache.uninstall_cache()
 
 
-@patch.object(BaseCache, 'remove_expired_responses')
-def test_remove_expired_responses__cache_not_installed(remove_expired_responses):
+@patch.object(BaseCache, 'remove')
+def test_remove_expired_responses__cache_not_installed(mock_remove):
     requests_cache.remove_expired_responses()
-    assert remove_expired_responses.called is False
+    assert mock_remove.called is False


### PR DESCRIPTION
Closes #643, updates #622, updates #651

New `BaseCache` method signatures:
```python
def remove(
    expired: bool = True,
    invalid: bool = True,
    older_than: datetime = None,
):
    ...

def reset_expiration(expire_after: ExpirationTime = None):
    ...
```

`BaseCache.remove_expired_responses()` is still available, but marked as deprecated.