### PR TITLE
Misc cleanup

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,7 +30,7 @@
 
 **Backends:**
 * SQLite:
-  * Improve performance for removing expired items
+  * Improve performance for removing expired responses with `delete()`
   * Add `size()` method to get estimated size of the database (including in-memory databases)
   * Add `sorted()` method with sorting and other query options
   * Add `wal` parameter to enable write-ahead logging

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -329,7 +329,7 @@ class BaseStorage(MutableMapping[KT, VT], ABC):
         # Wrap in a SerializerPipeline, if needed
         if not isinstance(serializer, SerializerPipeline):
             serializer = SerializerPipeline([serializer], name=str(serializer))
-        serializer.decode_content = decode_content
+        serializer.set_decode_content(decode_content)
 
         self.serializer = serializer
         logger.debug(f'Initialized {type(self).__name__} with serializer: {self.serializer}')

--- a/requests_cache/models/raw_response.py
+++ b/requests_cache/models/raw_response.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 from logging import getLogger
-from typing import Mapping
+from typing import TYPE_CHECKING
 
 from attr import define, field, fields_dict
 from requests import Response
@@ -15,50 +15,49 @@ from . import RichMixin
 logger = getLogger(__name__)
 
 
+if TYPE_CHECKING:
+    from . import CachedResponse
+
+
 @define(auto_attribs=False, repr=False, slots=False)
 class CachedHTTPResponse(RichMixin, HTTPResponse):
-    """A serializable dataclass that emulates :py:class:`~urllib3.response.HTTPResponse`.
-    Supports streaming requests and generator usage.
+    """A wrapper class that emulates :py:class:`~urllib3.response.HTTPResponse`.
 
-    The only action this doesn't support is explicitly calling :py:meth:`.read` with
-    ``decode_content=False``.
+    This enables consistent behavior for streaming requests and generator usage in the following
+    cases:
+    * On an original response, after reading its content to write to the cache
+    * On a cached response
     """
 
     decode_content: bool = field(default=None)
-    # These headers are redundant and not serialized; copied in init and CachedResponse post-init
-    headers: HTTPHeaderDict = None  # type: ignore
+    headers: HTTPHeaderDict = field(factory=HTTPHeaderDict)
     reason: str = field(default=None)
     request_url: str = field(default=None)
     status: int = field(default=0)
     strict: int = field(default=0)
     version: int = field(default=0)
 
-    def __init__(self, *args, body: bytes = None, headers: Mapping = None, **kwargs):
+    def __init__(self, body: bytes = None, **kwargs):
         """First initialize via HTTPResponse, then via attrs"""
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
         super().__init__(body=BytesIO(body or b''), preload_content=False, **kwargs)
-
         self._body = body
-        self.headers = HTTPHeaderDict(headers)
-        self.__attrs_init__(*args, **kwargs)  # type: ignore # False positive in mypy 0.920+?
+        self.__attrs_init__(**kwargs)  # type: ignore # False positive in mypy 0.920+?
 
     @classmethod
-    def from_response(cls, original_response: Response):
+    def from_response(cls, response: Response):
         """Create a CachedHTTPResponse based on an original response"""
         # Copy basic attributes
-        raw = original_response.raw
-        copy_attrs = list(fields_dict(cls).keys()) + ['headers']
-        kwargs = {k: getattr(raw, k, None) for k in copy_attrs}
-
-        # Note: _request_url is not available in urllib <=1.21
-        kwargs['request_url'] = getattr(raw, '_request_url', None)
+        raw = response.raw
+        kwargs = {k: getattr(raw, k, None) for k in fields_dict(cls).keys()}
+        kwargs['request_url'] = raw._request_url
 
         # Copy response data and restore response object to its original state
         if hasattr(raw, '_fp') and not is_fp_closed(raw._fp):
             body = raw.read(decode_content=False)
             kwargs['body'] = body
             raw._fp = BytesIO(body)
-            original_response.content  # This property reads, decodes, and stores response content
+            response.content  # This property reads, decodes, and stores response content
 
             # After reading, reset file pointer on original raw response
             raw._fp = BytesIO(body)
@@ -67,6 +66,18 @@ class CachedHTTPResponse(RichMixin, HTTPResponse):
 
         return cls(**kwargs)  # type: ignore  # False positive in mypy 0.920+?
 
+    @classmethod
+    def from_cached_response(cls, response: 'CachedResponse'):
+        """Create a CachedHTTPResponse based on a cached response"""
+        obj = cls(
+            headers=HTTPHeaderDict(response.headers),
+            reason=response.reason,
+            status=response.status_code,
+            request_url=response.request.url,
+        )
+        obj.reset(response._content)
+        return obj
+
     def release_conn(self):
         """No-op for compatibility"""
 
@@ -74,7 +85,7 @@ class CachedHTTPResponse(RichMixin, HTTPResponse):
         """Simplified reader for cached content that emulates
         :py:meth:`urllib3.response.HTTPResponse.read()`
         """
-        if 'content-encoding' in self.headers and decode_content is False:
+        if 'Content-Encoding' in self.headers and decode_content is False:
             logger.warning('read(decode_content=False) is not supported for cached responses')
 
         data = self._fp.read(amt)

--- a/requests_cache/serializers/cattrs.py
+++ b/requests_cache/serializers/cattrs.py
@@ -19,7 +19,6 @@ from cattr import GenConverter
 from requests.cookies import RequestsCookieJar, cookiejar_from_dict
 from requests.exceptions import JSONDecodeError
 from requests.structures import CaseInsensitiveDict
-from urllib3._collections import HTTPHeaderDict
 
 from ..models import CachedResponse, DecodedContent
 from .pipeline import Stage
@@ -102,9 +101,6 @@ def init_converter(
     converter.register_structure_hook(
         CaseInsensitiveDict, lambda obj, cls: CaseInsensitiveDict(obj)
     )
-    converter.register_unstructure_hook(HTTPHeaderDict, dict)
-    converter.register_structure_hook(HTTPHeaderDict, lambda obj, cls: HTTPHeaderDict(obj))
-
     # Convert decoded JSON body back to string
     converter.register_structure_hook(
         DecodedContent, lambda obj, cls: json.dumps(obj) if isinstance(obj, dict) else obj

--- a/requests_cache/serializers/pipeline.py
+++ b/requests_cache/serializers/pipeline.py
@@ -60,20 +60,11 @@ class SerializerPipeline:
             value = step(value)
         return value
 
-    # TODO: I don't love this. Could BaseStorage init be refactored to not need this getter/setter?
-    @property
-    def decode_content(self) -> bool:
-        for stage in self.stages:
-            if hasattr(stage, 'decode_content'):
-                return stage.decode_content
-        return False
-
-    @decode_content.setter
-    def decode_content(self, value: bool):
+    def set_decode_content(self, decode_content: bool):
         """Set decode_content, if the pipeline contains a CattrStage or compatible object"""
         for stage in self.stages:
             if hasattr(stage, 'decode_content'):
-                stage.decode_content = value
+                stage.decode_content = decode_content
 
     def __str__(self) -> str:
         return f'SerializerPipeline(name={self.name}, n_stages={len(self.dump_stages)})'

--- a/tests/integration/test_filesystem.py
+++ b/tests/integration/test_filesystem.py
@@ -82,15 +82,16 @@ class TestFileCache(BaseCacheTest):
         """Test all relevant combinations of response formats X serializers"""
         if not _valid_serializer(serializer):
             pytest.skip(f'Dependencies not installed for {serializer}')
+        serializer.set_decode_content(False)
         super().test_all_response_formats(response_format, serializer)
 
     @pytest.mark.parametrize('serializer', [json_serializer, yaml_serializer])
     @pytest.mark.parametrize('response_format', HTTPBIN_FORMATS)
     def test_all_response_formats__no_decode_content(self, response_format, serializer):
-        """Test with decode_content=False for text-based serialization formats"""
+        """Test with decode_content=True for text-based serialization formats"""
         if not _valid_serializer(serializer):
             pytest.skip(f'Dependencies not installed for {serializer}')
-        serializer.decode_content = False
+        serializer.set_decode_content(True)
         self.test_all_response_formats(response_format, serializer)
 
     @pytest.mark.parametrize('serializer_name', SERIALIZERS.keys())


### PR DESCRIPTION
Closes #653

* Use more efficient SQL query in SQLiteCache if using `.filter()` for expired responses only
* Remove `SerializerPipeline.decode_content` property, just make it a setter method
* Remove (redundant) HTTPResponse attributes from the cache
* Reconstruct CachedResponse.raw after deserialization