### PR TITLE
Improvements for deployment workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       # Start integration test databases
       - uses: supercharge/mongodb-github-action@1.8.0
         with:
-          mongodb-version: 4.4
+          mongodb-version: 5.0
       - uses: supercharge/redis-github-action@1.4.0
         with:
           redis-version: 6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,18 +23,11 @@ env:
   STRESS_TEST_MULTIPLIER: 7
 
 jobs:
-  # Run tests for all supported requests versions and minimum supported python version
-  test:
+
+  # Run additional integration stress tests
+  test-stress:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7]
-        requests-version: [2.22, 2.23, 2.24, 2.25, 2.26, 2.27, 2.28]
-        # Run tests for most recent python and requests versions
-        include:
-          - python-version: '3.10'
-            requests-version: latest
-      fail-fast: false
+
     services:
       nginx:
         image: kennethreitz/httpbin
@@ -46,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.LATEST_PY_VERSION }}
       - uses: snok/install-poetry@v1.3
         with:
           virtualenvs-in-project: true
@@ -66,18 +59,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ matrix.python-version }}-${{ matrix.requests-version }}-${{ hashFiles('poetry.lock') }}
+          key: venv-${{ env.LATEST_PY_VERSION }}-latest-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          poetry add requests@${{ matrix.requests-version }} --lock
-          poetry install -v -E all
+        run: poetry install -v -E all
 
-      # Run unit + integration tests
-      - name: Run tests
-        run: |
-          source $VENV
-          nox -e test-current
+      # Run tests
+      - name: Run stress tests
+        run: poetry run nox -e stress -- ${{ env.STRESS_TEST_MULTIPLIER }}
 
   # Run unit tests without any optional dependencies installed
   test-minimum-deps:
@@ -104,21 +93,26 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: poetry install -v
 
-      - name: Run unit tests with no optional dependencies
-        run: |
-          source $VENV
-          pytest -n auto tests/unit
+      # Run tests
+      - name: Run tests with no optional dependencies
+        run: poetry run pytest -n auto tests/unit
 
-  # Run additional stress tests
-  test-stress:
-    runs-on: ubuntu-latest
+  # Run unit tests for all supported platforms, python versions, and requests versions
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9, '3.10']
+        requests-version: [2.22, 2.23, 2.24, 2.25, 2.26, 2.27, latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
     steps:
       # Set up python + poetry
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.LATEST_PY_VERSION }}
+          python-version: ${{ matrix.python-version }}
       - uses: snok/install-poetry@v1.3
         with:
           virtualenvs-in-project: true
@@ -129,15 +123,16 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ env.LATEST_PY_VERSION }}-latest-${{ hashFiles('poetry.lock') }}
+          key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.requests-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: poetry install -v -E all
-
-      - name: Run stress tests
         run: |
-          source $VENV
-          nox -e stress -- ${{ env.STRESS_TEST_MULTIPLIER }}
+          poetry add requests@${{ matrix.requests-version }} --lock
+          poetry install -v -E all
+
+      # Run tests
+      - name: Run tests
+        run: poetry run pytest -n auto tests/unit
 
   # Deploy stable builds on tags only, and pre-release builds from manual trigger ("workflow_dispatch")
   release:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ on:
 env:
   LATEST_PY_VERSION: '3.10'
   PYTEST_VERBOSE: 'true'
-  STRESS_TEST_MULTIPLIER: 5
+  STRESS_TEST_MULTIPLIER: 7
 
 jobs:
   # Run tests for all supported requests versions and minimum supported python version
@@ -54,7 +54,7 @@ jobs:
       # Start integration test databases
       - uses: supercharge/mongodb-github-action@1.8.0
         with:
-          mongodb-version: 4.4
+          mongodb-version: 5.0
       - uses: supercharge/redis-github-action@1.4.0
         with:
           redis-version: 6
@@ -73,12 +73,11 @@ jobs:
           poetry add requests@${{ matrix.requests-version }} --lock
           poetry install -v -E all
 
-      # Run unit + integration tests, with additional stress tests
+      # Run unit + integration tests
       - name: Run tests
         run: |
           source $VENV
           nox -e test-current
-          nox -e stress -- ${{ env.STRESS_TEST_MULTIPLIER }}
 
   # Run unit tests without any optional dependencies installed
   test-minimum-deps:
@@ -92,7 +91,6 @@ jobs:
           python-version: ${{ env.LATEST_PY_VERSION }}
       - uses: snok/install-poetry@v1.3
         with:
-          version: 1.2.0b1
           virtualenvs-in-project: true
 
       # Cache packages per python version, and reuse until lockfile changes
@@ -111,17 +109,46 @@ jobs:
           source $VENV
           pytest -n auto tests/unit
 
+  # Run additional stress tests
+  test-stress:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Set up python + poetry
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.LATEST_PY_VERSION }}
+      - uses: snok/install-poetry@v1.3
+        with:
+          virtualenvs-in-project: true
+
+      # Cache packages per python version, and reuse until lockfile changes
+      - name: Cache python packages
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ env.LATEST_PY_VERSION }}-latest-${{ hashFiles('poetry.lock') }}
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: poetry install -v -E all
+
+      - name: Run stress tests
+        run: |
+          source $VENV
+          nox -e stress -- ${{ env.STRESS_TEST_MULTIPLIER }}
 
   # Deploy stable builds on tags only, and pre-release builds from manual trigger ("workflow_dispatch")
   release:
-    needs: [test, test-minimum-deps]
+    needs: [test, test-minimum-deps, test-stress]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.LATEST_PY_VERSION }}
-      - uses: snok/install-psoetry@v1.3
+      - uses: snok/install-poetry@v1.3
         with:
           virtualenvs-in-project: true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,14 @@ on:
         description: 'Version number for pre-releases; defaults to build number'
         required: false
         default: ''
+      skip-stress:
+        description: 'Set to "true" to skip stress tests'
+        required: false
+        default: 'false'
+      skip-publish:
+        description: 'Set to "true" to skip publishing to PyPI'
+        required: false
+        default: 'false'
 
 env:
   LATEST_PY_VERSION: '3.10'
@@ -26,6 +34,7 @@ jobs:
 
   # Run additional integration stress tests
   test-stress:
+    if: ${{ github.event.inputs.skip-stress != 'true' }}
     runs-on: ubuntu-latest
 
     services:
@@ -66,7 +75,9 @@ jobs:
 
       # Run tests
       - name: Run stress tests
-        run: poetry run nox -e stress -- ${{ env.STRESS_TEST_MULTIPLIER }}
+        run: |
+          source $VENV
+          nox -e stress -- ${{ env.STRESS_TEST_MULTIPLIER }}
 
   # Run unit tests without any optional dependencies installed
   test-minimum-deps:
@@ -95,7 +106,9 @@ jobs:
 
       # Run tests
       - name: Run tests with no optional dependencies
-        run: poetry run pytest -n auto tests/unit
+        run: |
+          source $VENV
+          pytest -n auto tests/unit
 
   # Run unit tests for all supported platforms, python versions, and requests versions
   test:
@@ -136,6 +149,7 @@ jobs:
 
   # Deploy stable builds on tags only, and pre-release builds from manual trigger ("workflow_dispatch")
   release:
+    if: ${{ github.event.inputs.skip-publish != 'true' }}
     needs: [test, test-minimum-deps, test-stress]
     runs-on: ubuntu-latest
     steps:
@@ -156,7 +170,7 @@ jobs:
           poetry version $(poetry version -s).${{ env.pre-release-suffix }}${{ env.pre-release-version }}
           poetry version
 
-      - name: Build and publish to pypi
+      - name: Build and publish to PyPI
         run: |
           poetry build
           poetry publish -u  __token__ -p ${{ secrets.PYPI_TOKEN }}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -89,6 +89,7 @@
 * Fix usage of memory backend with `install_cache()`
 * Add `CachedRequest.path_url` property for compatibility with `RequestEncodingMixin`
 * Add compatibility with cattrs 22.1+
+* Fix issue on Windows with occasional missing `CachedResponse.created_at` timestamp
 
 **Dependencies:**
 * Replace `appdirs` with `platformdirs`

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -247,7 +247,8 @@ class BaseCache:
 
     def delete_url(self, url: str, method: str = 'GET', **kwargs):
         warn(
-            'BaseCache.delete_url() is deprecated; please use .delete() instead', DeprecationWarning
+            'BaseCache.delete_url() is deprecated; please use .delete() instead',
+            DeprecationWarning,
         )
         self.delete(requests=[Request(method, url, **kwargs)])
 
@@ -260,14 +261,15 @@ class BaseCache:
 
     def has_url(self, url: str, method: str = 'GET', **kwargs) -> bool:
         warn(
-            'BaseCache.has_url() is deprecated; please use .contains() instead', DeprecationWarning
+            'BaseCache.has_url() is deprecated; please use .contains() instead',
+            DeprecationWarning,
         )
         return self.contains(request=Request(method, url, **kwargs))
 
     def keys(self, check_expiry: bool = False) -> Iterator[str]:
         warn(
-            'BaseCache.keys() is deprecated; please use .filter() or '
-            'BaseCache.responses.keys() instead',
+            'BaseCache.keys() is deprecated; '
+            'please use .filter() or BaseCache.responses.keys() instead',
             DeprecationWarning,
         )
         yield from self.redirects.keys()
@@ -276,15 +278,16 @@ class BaseCache:
 
     def response_count(self, check_expiry: bool = False) -> int:
         warn(
-            'BaseCache.response_count() is deprecated; please use .filter() or '
-            'len(BaseCache.responses) instead',
+            'BaseCache.response_count() is deprecated; '
+            'please use .filter() or len(BaseCache.responses) instead',
             DeprecationWarning,
         )
         return len(list(self.filter(expired=not check_expiry)))
 
     def remove_expired_responses(self, expire_after: ExpirationTime = None):
         warn(
-            'BaseCache.remove_expired_responses() is deprecated; please use .delete() instead',
+            'BaseCache.remove_expired_responses() is deprecated; '
+            'please use .delete(expired=True) instead',
             DeprecationWarning,
         )
         self.delete(expired=True, invalid=True)

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -66,7 +66,7 @@ class CachedResponse(RichMixin, BaseResponse):
     _decoded_content: DecodedContent = field(default=None)
     _next: Optional[CachedRequest] = field(default=None)
     cookies: RequestsCookieJar = field(factory=RequestsCookieJar)
-    created_at: datetime = field(factory=datetime.utcnow)
+    created_at: datetime = field(default=None)
     elapsed: timedelta = field(factory=timedelta)
     encoding: str = field(default=None)
     expires: Optional[datetime] = field(default=None)
@@ -79,7 +79,9 @@ class CachedResponse(RichMixin, BaseResponse):
     url: str = field(default=None)
 
     def __attrs_post_init__(self):
-        """Re-initialize raw (urllib3) response after deserialization"""
+        # Not using created_at field default due to possible bug on Windows with omit_if_default
+        self.created_at = self.created_at or datetime.utcnow()
+        # Re-initialize raw (urllib3) response after deserialization
         self.raw = self.raw or CachedHTTPResponse.from_cached_response(self)
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ Note: The protocol ``http(s)+mock://`` helps :py:class:`requests_mock.Adapter` p
 https://requests-mock.readthedocs.io/en/latest/adapter.html
 """
 import os
+import warnings
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from functools import wraps
 from importlib import import_module
@@ -276,6 +278,14 @@ def skip_missing_deps(module_name: str) -> pytest.Mark:
     return pytest.mark.skipif(
         not is_installed(module_name), reason=f'{module_name} is not installed'
     )
+
+
+@contextmanager
+def ignore_deprecation():
+    """Temporarily ilence deprecation warnings"""
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=DeprecationWarning)
+        yield
 
 
 # Some tests must disable url normalization to retain the custom `http+mock://` protocol

--- a/tests/unit/test_base_cache.py
+++ b/tests/unit/test_base_cache.py
@@ -59,7 +59,8 @@ def test_delete__expired(mock_normalize_url, mock_session):
     mock_session.settings.expire_after = 1
     mock_session.get(MOCKED_URL)
     mock_session.get(MOCKED_URL_JSON)
-    sleep(1)
+    sleep(1.1)
+    mock_session.settings.expire_after = 2
     mock_session.get(unexpired_url)
 
     # At this point we should have 1 unexpired response and 2 expired responses
@@ -72,7 +73,7 @@ def test_delete__expired(mock_normalize_url, mock_session):
     assert cached_response.url == unexpired_url
 
     # Now the last response should be expired as well
-    sleep(1)
+    sleep(2)
     BaseCache.delete(mock_session.cache, expired=True)
     assert len(mock_session.cache.responses) == 0
 

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -6,7 +6,7 @@ from requests.sessions import Session as OriginalSession
 import requests_cache
 from requests_cache import CachedSession
 from requests_cache.backends import BaseCache, SQLiteCache
-from tests.conftest import CACHE_NAME
+from tests.conftest import CACHE_NAME, ignore_deprecation
 
 
 def test_install_uninstall():
@@ -98,6 +98,7 @@ def test_delete__cache_not_installed(mock_delete):
 @patch.object(BaseCache, 'delete')
 def test_remove_expired_responses(mock_delete):
     requests_cache.install_cache(backend='memory', expire_after=360)
-    requests_cache.remove_expired_responses()
+    with ignore_deprecation():
+        requests_cache.remove_expired_responses()
     assert mock_delete.called is True
     requests_cache.uninstall_cache()

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -29,6 +29,7 @@ from tests.conftest import (
     MOCKED_URL_REDIRECT,
     MOCKED_URL_REDIRECT_TARGET,
     MOCKED_URL_VARY,
+    ignore_deprecation,
     patch_normalize_url,
 )
 
@@ -895,6 +896,6 @@ def test_request_force_refresh__prepared_request(mock_session):
 
 
 def test_remove_expired_responses(mock_session):
-    with patch.object(mock_session.cache, 'delete') as mock_delete:
+    with ignore_deprecation(), patch.object(mock_session.cache, 'delete') as mock_delete:
         mock_session.remove_expired_responses()
         mock_delete.assert_called_once_with(expired=True, invalid=True)


### PR DESCRIPTION
* Run pre-deploy stress tests as a separate job
* Run pre-deploy unit tests for all supported combinations of platforms, python versions, and requests versions
* Add option to run pre-deploy tests without publishing to PyPI
* Silence DeprecationWarnings during tests for deprecated methods
* Fix issue on Windows with occasional missing `CachedResponse.created_at` timestamp