### PR TITLE
Add 'url' argument to BaseCache.contains() and delete()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,8 +17,8 @@
 
 **Session settings:**
 * All settings that affect cache behavior can now be accessed and modified via `CachedSession.settings`
-* Add `always_revalidate` session setting to always revalidate before using a cached response (if a validator) is available.
-* Add `only_if_cached` settion setting to return only cached results without sending real requests
+* Add `always_revalidate` session setting to always revalidate before using a cached response (if a validator is available).
+* Add `only_if_cached` session setting to return only cached results without sending real requests
 * Add `stale_while_revalidate` session setting to return a stale response initially, while a non-blocking request is sent to refresh the response
 * Make behavior for `stale_if_error` partially consistent with `Cache-Control: stale-if-error`: Add support for time values (int, timedelta, etc.) in addition to `True/False`
 
@@ -65,9 +65,11 @@
 
 **Cache convenience methods:**
 * Add `expired` and `invalid` arguments to `BaseCache.delete()` (to replace `remove_expired_responses()`)
+* Add `urls` and `requests` arguments to `BaseCache.delete()` (to replace `delete_url()`)
 * Add `older_than` argument to `BaseCache.delete()` to delete responses older than a given value
 * Add `requests` argument to `BaseCache.delete()` to delete responses matching the given requests
 * Add `BaseCache.contains()` method to check for cached requests either by key or by `requests.Request` object
+* Add `url` argument to `BaseCache.contains()` method (to replace `has_url()`)
 * Add `BaseCache.filter()` method to get responses from the cache with various filters
 * Add `BaseCache.reset_expiration()` method to reset expiration for existing responses
 * Add `BaseCache.recreate_keys()` method to recreate cache keys for all previously cached responses
@@ -87,9 +89,9 @@
 
 **Bugfixes:**
 * Fix usage of memory backend with `install_cache()`
+* Fix issue on Windows with occasional missing `CachedResponse.created_at` timestamp
 * Add `CachedRequest.path_url` property for compatibility with `RequestEncodingMixin`
 * Add compatibility with cattrs 22.1+
-* Fix issue on Windows with occasional missing `CachedResponse.created_at` timestamp
 
 **Dependencies:**
 * Replace `appdirs` with `platformdirs`
@@ -98,12 +100,12 @@
 
 The following methods are deprecated, and will be removed in a future release. The recommended
 replacements are listed below:
-* `BaseCache.remove_expired_responses()`: `BaseCache.delete()`
-* `CachedSession.remove_expired_responses()`: `BaseCache.delete()`
-* `BaseCache.delete_url()`: `BaseCache.delete()`
-* `BaseCache.delete_urls()`: `BaseCache.delete()`
+* `BaseCache.remove_expired_responses()`: `BaseCache.delete(expired=True)`
+* `CachedSession.remove_expired_responses()`: `BaseCache.delete(expired=True)`
+* `BaseCache.delete_url()`: `BaseCache.delete(urls=[...])`
+* `BaseCache.delete_urls()`: `BaseCache.delete(urls=[...])`
 * `BaseCache.has_key()`: `BaseCache.contains()`
-* `BaseCache.has_url()`: `BaseCache.contains()`
+* `BaseCache.has_url()`: `BaseCache.contains(url=...)`
 * `BaseCache.keys()`: `BaseCache.filter()`
 * `BaseCache.values()`: `BaseCache.filter()`
 * `BaseCache.response_count()`: `BaseCache.filter()`

--- a/docs/user_guide/expiration.md
+++ b/docs/user_guide/expiration.md
@@ -181,15 +181,20 @@ Or apply a new expiration value to previously cached responses:
 >>> session.cache.reset_expiration(timedelta(days=30))
 ```
 
-Finally, you can delete responses matching specific requests or {ref}`cache keys <custom-matching>`:
+Finally, you can delete individual responses matching specific requests or
+{ref}`cache keys <custom-matching>`:
 ```python
 >>> from requests import Request
->>> request_1 = Request('GET', 'https://httpbin.org/get')
->>> request_2 = Request('GET', 'https://httpbin.org/get', params={'key': 'value'})
->>> session.cache.delete(requests=[request_1, request_2])
-```
 
-```python
+# Delete a simple GET request by URL
+>>> session.cache.delete(urls=['https://httpbin.org/json'])
+
+# Delete by additional request values
+>>> request_1 = Request('GET', 'https://httpbin.org/get', params={'key': 'value'})
+>>> request_2 = Request('GET', 'https://httpbin.org/get', headers={'header': 'value'})
+>>> session.cache.delete(requests=[request_1, request_2])
+
+# Delete by cache key
 >>> session.cache.delete('e25f7e6326966e82')
 ```
 

--- a/docs/user_guide/inspection.md
+++ b/docs/user_guide/inspection.md
@@ -42,7 +42,14 @@ True 2021-01-01 18:00:00 2021-01-02 18:00:00 False
 
 ### Checking for responses
 Use {py:meth}`.BaseCache.contains` to check if a given request is cached.
-Either check with a {py:class}`~requests.models.Request` object:
+
+Check if a specific URL is cached:
+```python
+>>> print(session.cache.contains(url='https://httpbin.org/get'))
+```
+
+To match additional request values (parameters, headers, etc), you can pass a
+{py:class}`~requests.models.Request` object instead:
 ```python
 >>> from requests import Request
 
@@ -50,7 +57,7 @@ Either check with a {py:class}`~requests.models.Request` object:
 >>> print(session.cache.contains(request=request))
 ```
 
-Or with a cache key:
+You can also check for a specific cache key:
 ```python
 >>> print(session.cache.contains('d1e666e9fdfb3f86'))
 ```

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -124,13 +124,17 @@ class BaseCache:
         self,
         key: str = None,
         request: AnyRequest = None,
+        url: str = None,
     ):
         """Check if the specified request is cached
 
         Args:
             key: Check for a specific cache key
             request: Check for a matching request, according to current request matching settings
+            url: Check for a matching GET request with the specified URL
         """
+        if url:
+            request = Request('GET', url)
         if request and not key:
             key = self.create_key(request)
         return key in self.responses or key in self.redirects
@@ -142,6 +146,7 @@ class BaseCache:
         invalid: bool = False,
         older_than: ExpirationTime = None,
         requests: Iterable[AnyRequest] = None,
+        urls: Iterable[str] = None,
     ):
         """Remove responses from the cache according one or more conditions.
 
@@ -151,8 +156,11 @@ class BaseCache:
             invalid: Remove all invalid responses (that can't be deserialized with current settings)
             older_than: Remove responses older than this value, relative to ``response.created_at``
             requests: Remove matching responses, according to current request matching settings
+            urls: Remove matching GET requests for the specified URL(s)
         """
         delete_keys: List[str] = list(keys) if keys else []
+        if urls:
+            requests = list(requests or []) + [Request('GET', url).prepare() for url in urls]
         if requests:
             delete_keys += [self.create_key(request) for request in requests]
 
@@ -247,21 +255,21 @@ class BaseCache:
 
     def delete_url(self, url: str, method: str = 'GET', **kwargs):
         warn(
-            'BaseCache.delete_url() is deprecated; please use .delete() instead',
+            'BaseCache.delete_url() is deprecated; please use .delete(urls=...) instead',
             DeprecationWarning,
         )
         self.delete(requests=[Request(method, url, **kwargs)])
 
     def delete_urls(self, urls: Iterable[str], method: str = 'GET', **kwargs):
         warn(
-            'BaseCache.delete_urls() is deprecated; please use .delete() instead',
+            'BaseCache.delete_urls() is deprecated; please use .delete(urls=...) instead',
             DeprecationWarning,
         )
         self.delete(requests=[Request(method, url, **kwargs) for url in urls])
 
     def has_url(self, url: str, method: str = 'GET', **kwargs) -> bool:
         warn(
-            'BaseCache.has_url() is deprecated; please use .contains() instead',
+            'BaseCache.has_url() is deprecated; please use .contains(url=...) instead',
             DeprecationWarning,
         )
         return self.contains(request=Request(method, url, **kwargs))

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -302,8 +302,8 @@ class BaseCacheTest:
 
         assert len(session.cache.responses.keys()) == 2
         assert len(session.cache.redirects.keys()) == 3
-        assert not session.cache.has_url(httpbin('redirect/1'))
-        assert not any([session.cache.has_url(httpbin(f)) for f in HTTPBIN_FORMATS])
+        assert not session.cache.contains(url=httpbin('redirect/1'))
+        assert not any([session.cache.contains(url=httpbin(f)) for f in HTTPBIN_FORMATS])
 
     @pytest.mark.parametrize('method', HTTPBIN_METHODS)
     def test_filter_request_headers(self, method):

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -61,9 +61,9 @@ class TestMongoCache(BaseCacheTest):
         response = session.get(httpbin('get'))
         assert response.from_cache is True
 
-        # Wait up to 60 seconds for removal background process to run
+        # Wait for removal background process to run
         # Unfortunately there doesn't seem to be a way to manually trigger it
-        for i in range(60):
+        for i in range(70):
             if response.cache_key not in session.cache.responses:
                 logger.debug(f'Removed {response.cache_key} after {i} seconds')
                 break

--- a/tests/unit/test_base_cache.py
+++ b/tests/unit/test_base_cache.py
@@ -50,6 +50,12 @@ def test_contains__request(mock_session):
     assert not mock_session.cache.contains(request=request)
 
 
+def test_contains__url(mock_session):
+    mock_session.get(MOCKED_URL)
+    assert mock_session.cache.contains(url=MOCKED_URL)
+    assert not mock_session.cache.contains(url=f'{MOCKED_URL}?foo=bar')
+
+
 @patch_normalize_url
 def test_delete__expired(mock_normalize_url, mock_session):
     unexpired_url = f'{MOCKED_URL}?x=1'
@@ -151,6 +157,17 @@ def test_delete__older_than(mock_session):
     assert len(mock_session.cache.responses) == 0
 
 
+def test_delete__urls(mock_session):
+    urls = [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_REDIRECT]
+    for url in urls:
+        mock_session.get(url)
+
+    mock_session.cache.delete(urls=urls)
+
+    for url in urls:
+        assert not mock_session.cache.contains(url=url)
+
+
 def test_delete__requests(mock_session):
     urls = [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_REDIRECT]
     for url in urls:
@@ -228,8 +245,8 @@ def test_clear(mock_session):
     mock_session.get(MOCKED_URL)
     mock_session.get(MOCKED_URL_REDIRECT)
     mock_session.cache.clear()
-    assert not mock_session.cache.contains(request=Request('GET', MOCKED_URL))
-    assert not mock_session.cache.contains(request=Request('GET', MOCKED_URL_REDIRECT))
+    assert not mock_session.cache.contains(url=MOCKED_URL)
+    assert not mock_session.cache.contains(url=MOCKED_URL_REDIRECT)
 
 
 def test_save_response__manual(mock_session):


### PR DESCRIPTION
Basically this is just to add a shortcut for checking/deleting a simple GET request by URL, similar to the `has_url()` and `delete_url()` methods that `contains()` and `delete()` have replaced.