### PR TITLE
Fix remove_expired_responses deprecation suggestion

### DIFF
--- a/requests_cache/session.py
+++ b/requests_cache/session.py
@@ -308,7 +308,7 @@ class CacheMixin(MIXIN_BASE):
         self.cache.close()
 
     def remove_expired_responses(self):
-        """**Deprecated:** Use ``session.cache.remove(expired=True)`` instead"""
+        """**Deprecated:** Use ``session.cache.delete(expired=True)`` instead"""
         self.cache.delete(expired=True, invalid=True)
 
     def __getstate__(self):


### PR DESCRIPTION
Fairly straightforward? I don't think `remove` even exists, and I assume it means to say `delete`.