### PR TITLE
Handle using a converter that doesn't support `omit_if_default`

### DIFF
--- a/requests_cache/serializers/cattrs.py
+++ b/requests_cache/serializers/cattrs.py
@@ -81,7 +81,11 @@ def init_converter(
             datetime support
     """
     factory = factory or Converter
-    converter = factory(omit_if_default=True)
+    try:
+        converter = factory(omit_if_default=True)
+    # Handle previous versions of cattrs (<22.2) that don't support this argument
+    except TypeError:
+        converter = factory()
 
     # Convert datetimes to and from iso-formatted strings
     if convert_datetime:

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -9,10 +9,12 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from cattr import BaseConverter, GenConverter
 
 from requests_cache import (
     CachedResponse,
     CachedSession,
+    CattrStage,
     SerializerPipeline,
     Stage,
     json_serializer,
@@ -128,3 +130,14 @@ def test_plain_pickle(tempfile_path):
     session.cache.responses['key'] = response
     assert session.cache.responses['key'] == response
     assert session.cache.responses['key'].expires is None
+
+
+def test_cattrs_compat():
+    """CattrStage should be compatible with BaseConverter, which doesn't support the omit_if_default
+    keyword arg.
+    """
+    stage_1 = CattrStage()
+    assert isinstance(stage_1.converter, GenConverter)
+
+    stage_2 = CattrStage(factory=BaseConverter)
+    assert isinstance(stage_2.converter, BaseConverter)


### PR DESCRIPTION
Related to #719

This could happen in one of two cases:
* A version of `cattrs` is installed older than the minimum pinned version (22.2)
* A custom serializer is made using `BaseConverter`