### PR TITLE
Sqlite improvements

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -51,6 +51,7 @@
   * Add `ttl_offset` argument to add a delay between cache expiration and deletion
 * **SQLite**:
   * Improve performance for removing expired responses with `delete()`
+  * Add `count()` method to count responses, with option to exclude expired responses (performs a fast indexed count instead of slower in-memory filtering)
   * Add `size()` method to get estimated size of the database (including in-memory databases)
   * Add `sorted()` method with sorting and other query options
   * Add `wal` parameter to enable write-ahead logging

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -70,11 +70,7 @@ class BaseCache:
                 response = self.responses[self.redirects[key]]
             response.cache_key = key
             return response
-        except KeyError:
-            return default
-        except DESERIALIZE_ERRORS as e:
-            logger.error(f'Unable to deserialize response {key}: {str(e)}')
-            logger.debug(e, exc_info=True)
+        except (AttributeError, KeyError):
             return default
 
     def save_response(self, response: Response, cache_key: str = None, expires: datetime = None):
@@ -394,16 +390,28 @@ class BaseStorage(MutableMapping[KT, VT], ABC):
         """Close any open backend connections"""
 
     def serialize(self, value: VT):
-        """Serialize value, if a serializer is available"""
+        """Serialize a value, if a serializer is available"""
         if TYPE_CHECKING:
             assert hasattr(self.serializer, 'dumps')
         return self.serializer.dumps(value) if self.serializer else value
 
     def deserialize(self, value: VT):
-        """Deserialize value, if a serializer is available"""
+        """Deserialize a value, if a serializer is available.
+
+        If deserialization fails (usually due to a value saved in an older requests-cache version),
+        ``None`` will be returned.
+        """
+        if not self.serializer:
+            return value
         if TYPE_CHECKING:
             assert hasattr(self.serializer, 'loads')
-        return self.serializer.loads(value) if self.serializer else value
+
+        try:
+            return self.serializer.loads(value)
+        except DESERIALIZE_ERRORS as e:
+            logger.error(f'Unable to deserialize response: {str(e)}')
+            logger.debug(e, exc_info=True)
+            return None
 
     def __str__(self):
         return str(list(self.keys()))

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -292,8 +292,11 @@ class BaseCache:
             DeprecationWarning,
         )
         yield from self.redirects.keys()
-        for response in self.filter(expired=not check_expiry):
-            yield response.cache_key
+        if not check_expiry:
+            yield from self.responses.keys()
+        else:
+            for response in self.filter(expired=False):
+                yield response.cache_key
 
     def response_count(self, check_expiry: bool = False) -> int:
         warn(

--- a/requests_cache/backends/sqlite.py
+++ b/requests_cache/backends/sqlite.py
@@ -18,6 +18,7 @@ from typing import Collection, Iterator, List, Tuple, Type, Union
 from platformdirs import user_cache_dir
 
 from requests_cache.models.response import CachedResponse
+from requests_cache.policy import ExpirationTime
 
 from .._utils import chunkify, get_valid_kwargs
 from . import BaseCache, BaseStorage
@@ -55,8 +56,8 @@ class SQLiteCache(BaseCache):
         return self.responses.db_path
 
     def clear(self):
-        """Clear the cache. If this fails due to a corrupted cache or other I/O error, this will
-        attempt to delete the cache file and re-initialize.
+        """Delete all items from the cache. If this fails due to a corrupted cache or other I/O
+        error, this will  attempt to delete the cache file and re-initialize.
         """
         try:
             super().clear()
@@ -67,13 +68,13 @@ class SQLiteCache(BaseCache):
             self.responses.init_db()
             self.redirects.init_db()
 
+    # A more efficient SQLite implementation of :py:meth:`BaseCache.delete`
     def delete(
         self,
         *keys: str,
         expired: bool = False,
         **kwargs,
     ):
-        """A more efficient SQLite implementation of :py:meth:`BaseCache.delete`"""
         if keys:
             self.responses.bulk_delete(keys)
         if expired:
@@ -117,19 +118,23 @@ class SQLiteCache(BaseCache):
         """
         return self.responses.count(expired=expired)
 
-    def filter(  # type: ignore
-        self, valid: bool = True, expired: bool = True, **kwargs
+    # A more efficient implementation of :py:meth:`BaseCache.filter` to make use of indexes
+    def filter(
+        self,
+        valid: bool = True,
+        expired: bool = True,
+        invalid: bool = False,
+        older_than: ExpirationTime = None,
     ) -> Iterator[CachedResponse]:
-        """A more efficient implementation of :py:meth:`BaseCache.filter`, in the case where we want
-        to get **only** expired responses
-        """
-        if expired and not valid and not kwargs:
-            return self.responses.sorted(expired=True)
+        if valid and not invalid:
+            return self.responses.sorted(expired=expired)
         else:
-            return super().filter(valid, expired, **kwargs)
+            return super().filter(
+                valid=valid, expired=expired, invalid=invalid, older_than=older_than
+            )
 
+    # A more efficient implementation of :py:meth:`BaseCache.recreate_keys
     def recreate_keys(self):
-        """A more efficient implementation of :py:meth:`BaseCache.recreate_keys`"""
         with self.responses.bulk_commit():
             super().recreate_keys()
 

--- a/requests_cache/backends/sqlite.py
+++ b/requests_cache/backends/sqlite.py
@@ -162,6 +162,8 @@ class SQLiteDict(BaseStorage):
         self._local_context = threading.local()
         self._lock = threading.RLock()
         self.connection_kwargs = get_valid_kwargs(sqlite_template, kwargs)
+        if use_memory:
+            self.connection_kwargs['uri'] = True
         self.db_path = _get_sqlite_cache_path(db_path, use_cache_dir, use_temp, use_memory)
         self.fast_save = fast_save
         self.table_name = table_name
@@ -172,7 +174,7 @@ class SQLiteDict(BaseStorage):
         """Initialize the database, if it hasn't already been"""
         self.close()
         with self._lock, self.connection() as con:
-            # Add new column to tables created before 0.10
+            # Add new column to tables created before 1.0
             try:
                 con.execute(f'ALTER TABLE {self.table_name} ADD COLUMN expires TEXT')
             except sqlite3.OperationalError:

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -16,7 +16,7 @@ import requests
 from requests import PreparedRequest, Session
 
 from requests_cache import ALL_METHODS, CachedResponse, CachedSession
-from requests_cache.backends.base import BaseCache
+from requests_cache.backends import BaseCache
 from tests.conftest import (
     CACHE_NAME,
     ETAG,
@@ -99,7 +99,7 @@ class BaseCacheTest:
 
         # Patch storage class to track number of times getitem is called, without changing behavior
         with patch.object(
-            storage_class, '__getitem__', side_effect=storage_class.__getitem__
+            storage_class, '__getitem__', side_effect=lambda k: CachedResponse()
         ) as getitem:
             session.get(httpbin('get'))
             assert getitem.call_count == 1

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -308,11 +308,15 @@ class TestSQLiteCache(BaseCacheTest):
         assert session.cache.count(expired=False) == 1
 
     @patch.object(SQLiteDict, 'sorted')
-    def test_filter__expired_only(self, mock_sorted):
-        """Filtering by expired only should use a more efficient SQL query"""
+    def test_filter__expired(self, mock_sorted):
+        """Filtering by expired should use a more efficient SQL query"""
         session = self.init_session()
-        session.cache.filter(valid=False, expired=True)
-        mock_sorted.assert_called_once_with(expired=True)
+
+        session.cache.filter()
+        mock_sorted.assert_called_with(expired=True)
+
+        session.cache.filter(expired=False)
+        mock_sorted.assert_called_with(expired=False)
 
     def test_sorted(self):
         """Test wrapper method for SQLiteDict.sorted(), with all arguments combined"""

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -297,6 +297,16 @@ class TestSQLiteCache(BaseCacheTest):
         session = self.init_session()
         assert session.cache.db_path == session.cache.responses.db_path
 
+    def test_count(self):
+        """count() should work the same as len(), but with the option to exclude expired responses"""
+        session = self.init_session()
+        now = datetime.utcnow()
+        session.cache.responses['key_1'] = CachedResponse(expires=now + timedelta(1))
+        session.cache.responses['key_2'] = CachedResponse(expires=now - timedelta(1))
+
+        assert session.cache.count() == 2
+        assert session.cache.count(expired=False) == 1
+
     @patch.object(SQLiteDict, 'sorted')
     def test_filter__expired_only(self, mock_sorted):
         """Filtering by expired only should use a more efficient SQL query"""

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 from datetime import datetime, timedelta
 from os.path import join
 from tempfile import NamedTemporaryFile, gettempdir
@@ -8,9 +9,9 @@ from unittest.mock import patch
 import pytest
 from platformdirs import user_cache_dir
 
-from requests_cache.backends.base import BaseCache
-from requests_cache.backends.sqlite import MEMORY_URI, SQLiteCache, SQLiteDict
-from requests_cache.models.response import CachedResponse
+from requests_cache.backends import BaseCache, SQLiteCache, SQLiteDict
+from requests_cache.backends.sqlite import MEMORY_URI
+from requests_cache.models import CachedResponse
 from tests.integration.base_cache_test import BaseCacheTest
 from tests.integration.base_storage_test import CACHE_NAME, BaseStorageTest
 
@@ -60,7 +61,7 @@ class TestSQLiteDict(BaseStorageTest):
         assert len(cache) == 0
 
     def test_use_memory__uri(self):
-        self.init_cache(':memory:').db_path == ':memory:'
+        assert self.init_cache(':memory:').db_path == ':memory:'
 
     def test_non_dir_parent_exists(self):
         """Expect a custom error message if a parent path already exists but isn't a directory"""
@@ -219,6 +220,30 @@ class TestSQLiteDict(BaseStorageTest):
             assert prev_item is None or prev_item.expires < item.expires
             assert item.status_code % 2 == 0
 
+    def test_sorted__error(self):
+        """sorted() should handle deserialization errors and not return invalid responses"""
+
+        class BadSerializer:
+            def loads(self, value):
+                response = pickle.loads(value)
+                if response.cache_key == 'key_42':
+                    raise pickle.PickleError()
+                return response
+
+            def dumps(self, value):
+                return pickle.dumps(value)
+
+        cache = self.init_cache(serializer=BadSerializer())
+
+        for i in range(100):
+            response = CachedResponse(status_code=i)
+            response.cache_key = f'key_{i}'
+            cache[f'key_{i}'] = response
+
+        # Items should only include unexpired (even numbered) items, and still be in sorted order
+        items = list(cache.sorted())
+        assert len(items) == 99
+
     @pytest.mark.parametrize(
         'db_path, use_temp',
         [
@@ -300,4 +325,5 @@ class TestSQLiteCache(BaseCacheTest):
         prev_item = None
         for i, item in enumerate(items):
             assert prev_item is None or prev_item.expires < item.expires
+            assert item.cache_key
             assert not item.is_expired

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -351,7 +351,8 @@ def test_include_get_headers():
 def test_cache_error(exception_cls, mock_session):
     """If there is an error while fetching a cached response, a new one should be fetched"""
     mock_session.get(MOCKED_URL)
-    with patch.object(SQLiteDict, '__getitem__', side_effect=exception_cls):
+
+    with patch.object(mock_session.cache.responses.serializer, 'loads', side_effect=exception_cls):
         assert mock_session.get(MOCKED_URL).from_cache is False
 
 
@@ -440,7 +441,7 @@ def test_unpickle_errors(mock_session):
     """If there is an error during deserialization, the request should be made again"""
     assert mock_session.get(MOCKED_URL_JSON).from_cache is False
 
-    with patch.object(SQLiteDict, '__getitem__', side_effect=PickleError):
+    with patch.object(mock_session.cache.responses.serializer, 'loads', side_effect=PickleError):
         resp = mock_session.get(MOCKED_URL_JSON)
         assert resp.from_cache is False
         assert resp.json()['message'] == 'mock json response'

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -17,7 +17,7 @@ from requests.structures import CaseInsensitiveDict
 
 from requests_cache import ALL_METHODS, CachedSession
 from requests_cache._utils import get_placeholder_class
-from requests_cache.backends import BACKEND_CLASSES, BaseCache, SQLiteDict
+from requests_cache.backends import BACKEND_CLASSES, BaseCache
 from requests_cache.backends.base import DESERIALIZE_ERRORS
 from requests_cache.policy.expiration import DO_NOT_CACHE, EXPIRE_IMMEDIATELY, NEVER_EXPIRE
 from tests.conftest import (


### PR DESCRIPTION
Closes #722

* Improve `SQLiteCache.sorted()`: exclude any invalid responses
* Add a `SQLiteCache.count()` method to count responses, with option to exclude expired responses (performs a fast indexed count instead of slower in-memory filtering)
* Make use of index with `SQLiteCache.filter(expired=False)`
* Set `uri=True` when using an in-memory SQLite db