### PR TITLE
Change initialization for backend-specific default serializers

### DIFF
--- a/requests_cache/serializers/__init__.py
+++ b/requests_cache/serializers/__init__.py
@@ -19,7 +19,7 @@ For any optional libraries that aren't installed, the corresponding serializer w
 class that raises an ``ImportError`` at initialization time instead of at import time.
 """
 # flake8: noqa: F401
-from typing import Union
+from typing import Optional, Union
 
 from .cattrs import CattrStage
 from .pipeline import SerializerPipeline, Stage
@@ -39,7 +39,9 @@ __all__ = [
     'SERIALIZERS',
     'CattrStage',
     'SerializerPipeline',
+    'SerializerType',
     'Stage',
+    'init_serializer',
     'bson_serializer',
     'bson_document_serializer',
     'dynamodb_document_serializer',
@@ -59,3 +61,22 @@ SERIALIZERS = {
 }
 
 SerializerType = Union[str, SerializerPipeline, Stage]
+
+
+def init_serializer(
+    serializer: Optional[SerializerType], decode_content: bool
+) -> Optional[SerializerPipeline]:
+    """Intitialze a serializer by name or instance"""
+    if not serializer:
+        return None
+
+    # Look up a serializer by name, if needed
+    if isinstance(serializer, str):
+        serializer = SERIALIZERS[serializer]
+
+    # Wrap in a SerializerPipeline, if needed
+    if not isinstance(serializer, SerializerPipeline):
+        serializer = SerializerPipeline([serializer], name=str(serializer))
+    serializer.set_decode_content(decode_content)
+
+    return serializer

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -48,7 +48,6 @@ class BaseCacheTest:
     def init_session(self, cache_name=CACHE_NAME, clear=True, **kwargs) -> CachedSession:
         kwargs = {**self.init_kwargs, **kwargs}
         kwargs.setdefault('allowable_methods', ALL_METHODS)
-        kwargs.setdefault('serializer', 'pickle')
         backend = self.backend_class(cache_name, **kwargs)
         if clear:
             backend.clear()

--- a/tests/integration/base_storage_test.py
+++ b/tests/integration/base_storage_test.py
@@ -19,7 +19,6 @@ class BaseStorageTest:
 
     def init_cache(self, cache_name=CACHE_NAME, index=0, clear=True, **kwargs):
         kwargs = {**self.init_kwargs, **kwargs}
-        kwargs.setdefault('serializer', 'pickle')
         cache = self.storage_class(cache_name, f'table_{index}', **kwargs)
         if clear:
             cache.clear()
@@ -136,8 +135,8 @@ class BaseStorageTest:
         cache_2 = self.init_cache(connection=getattr(cache_1, 'connection', None))
 
         for i in range(5):
-            cache_1[i] = i
-            cache_2[i] = i
+            cache_1[i] = f'value_{i}'
+            cache_2[i] = f'value_{i}'
 
         assert len(cache_1) == len(cache_2) == 5
         cache_1.clear()
@@ -147,8 +146,8 @@ class BaseStorageTest:
     def test_same_settings(self):
         cache_1 = self.init_cache()
         cache_2 = self.init_cache(connection=getattr(cache_1, 'connection', None))
-        cache_1['key_1'] = 1
-        cache_2['key_2'] = 2
+        cache_1['key_1'] = 'value_1'
+        cache_2['key_2'] = 'value_2'
         assert cache_1 == cache_2
 
     def test_str(self):

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -15,10 +15,6 @@ AWS_OPTIONS = {
     'aws_access_key_id': 'placeholder',
     'aws_secret_access_key': 'placeholder',
 }
-DYNAMODB_OPTIONS = {
-    **AWS_OPTIONS,
-    'serializer': None,  # Use class default serializer
-}
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -33,7 +29,7 @@ def ensure_connection():
 
 class TestDynamoDbDict(BaseStorageTest):
     storage_class = DynamoDbDict
-    init_kwargs = DYNAMODB_OPTIONS
+    init_kwargs = AWS_OPTIONS
 
     @patch('requests_cache.backends.dynamodb.boto3.resource')
     def test_connection_kwargs(self, mock_resource):
@@ -87,4 +83,4 @@ class TestDynamoDbDict(BaseStorageTest):
 
 class TestDynamoDbCache(BaseCacheTest):
     backend_class = DynamoDbCache
-    init_kwargs = DYNAMODB_OPTIONS
+    init_kwargs = AWS_OPTIONS

--- a/tests/integration/test_filesystem.py
+++ b/tests/integration/test_filesystem.py
@@ -39,7 +39,6 @@ class TestFileDict(BaseStorageTest):
         rmtree(CACHE_NAME, ignore_errors=True)
 
     def init_cache(self, index=0, clear=True, **kwargs):
-        kwargs.setdefault('serializer', 'pickle')
         cache = FileDict(f'{CACHE_NAME}_{index}', use_temp=True, **kwargs)
         if clear:
             cache.clear()

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -51,7 +51,6 @@ class TestMongoDict(BaseStorageTest):
 
 class TestMongoCache(BaseCacheTest):
     backend_class = MongoCache
-    init_kwargs = {'serializer': None}  # Use class default serializer instead of pickle
 
     def test_ttl(self):
         session = self.init_session()

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -33,6 +33,7 @@ class TestRedisHashDict(TestRedisDict):
     storage_class = RedisHashDict
     num_instances: int = 10  # Supports multiple instances, since this stores items under hash keys
     picklable = True
+    init_kwargs = {'serializer': 'pickle'}
 
 
 class TestRedisCache(BaseCacheTest):


### PR DESCRIPTION
This sets default serializers for each backend using param defaults instead of 'default_serializer' class attributes. This requires an extra check in the `__init__()` method of each backend class, but I think it's now a bit easier to follow.

Also, I wasn't quite happy with adding an extra `no_serializer` param to disambiguate between `serialzier=None` (keyword arg default) and explicitly disabling the serializer.