### PR TITLE
Raise an error for invalid expiration string values 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -110,6 +110,8 @@
 * Add `CachedRequest.path_url` property for compatibility with `RequestEncodingMixin`
 * Fix potential `AttributeError` due to undetected imports when requests-cache is bundled in a PyInstaller package
 * Fix `AttributeError` when attempting to unpickle a `CachedSession` object, and instead disable pickling by raising a `NotImplementedError`
+* Raise an error for invalid expiration string values (except for headers containing httpdates)
+  * Previously, this would be quietly ignored, and the response would be cached indefinitely
 
 📦 **Dependencies:**
 * Replace `appdirs` with `platformdirs`

--- a/tests/unit/policy/test_expiration.py
+++ b/tests/unit/policy/test_expiration.py
@@ -41,7 +41,9 @@ def test_get_expiration_datetime__tzinfo():
 
 def test_get_expiration_datetime__httpdate():
     assert get_expiration_datetime(HTTPDATE_STR) == HTTPDATE_DATETIME
-    assert get_expiration_datetime('P12Y34M56DT78H90M12.345S') is None
+    assert get_expiration_datetime('P12Y34M56DT78H90M12.345S', ignore_invalid_httpdate=True) is None
+    with pytest.raises(ValueError):
+        get_expiration_datetime('P12Y34M56DT78H90M12.345S')
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -660,6 +660,21 @@ def test_url_allowlist(mock_session):
     assert not mock_session.cache.contains(url=MOCKED_URL)
 
 
+def test_invalid_expiration(mock_session):
+    mock_session.settings.expire_after = 'tomorrow'
+    with pytest.raises(ValueError):
+        mock_session.get(MOCKED_URL)
+
+    mock_session.settings.expire_after = object()
+    with pytest.raises(TypeError):
+        mock_session.get(MOCKED_URL)
+
+    mock_session.settings.expire_after = None
+    mock_session.settings.urls_expire_after = {'*': 'tomorrow'}
+    with pytest.raises(ValueError):
+        mock_session.get(MOCKED_URL)
+
+
 def test_stale_while_revalidate(mock_session):
     # Start with expired responses
     mocked_url_2 = f'{MOCKED_URL_ETAG}?k=v'


### PR DESCRIPTION
(except for headers containing httpdates)

Fixes #762 