### PR TITLE
Raise an error for invalid expiration string values (v0.9)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,12 @@
 # History
 
-## 0.9.8 (Unreleased)
+## 0.9.8 (2023-01-13)
 * Fix `DeprecationWarning` raised by `BaseCache.urls`
 * Reword ambiguous log message for `BaseCache.delete`
+
+Backport fixes from 1.0:
 * For custom serializers, handle using a cattrs converter that doesn't support `omit_if_default`
+* Raise an error for invalid expiration string values (except for headers containing httpdates)
 
 ## 0.9.7 (2022-10-26)
 Backport compatibility fixes from 1.0:

--- a/tests/unit/policy/test_actions.py
+++ b/tests/unit/policy/test_actions.py
@@ -304,7 +304,7 @@ def test_get_expiration_datetime__tzinfo():
 
 def test_get_expiration_datetime__httpdate():
     assert get_expiration_datetime(HTTPDATE_STR) == HTTPDATE_DATETIME
-    assert get_expiration_datetime('P12Y34M56DT78H90M12.345S') is None
+    assert get_expiration_datetime('P12Y34M56DT78H90M12.345S', ignore_invalid_httpdate=True) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -659,6 +659,21 @@ def test_remove_expired_responses(mock_session):
     assert len(mock_session.cache.responses) == 0
 
 
+def test_invalid_expiration(mock_session):
+    mock_session.settings.expire_after = 'tomorrow'
+    with pytest.raises(ValueError):
+        mock_session.get(MOCKED_URL)
+
+    mock_session.settings.expire_after = object()
+    with pytest.raises(TypeError):
+        mock_session.get(MOCKED_URL)
+
+    mock_session.settings.expire_after = None
+    mock_session.settings.urls_expire_after = {'*': 'tomorrow'}
+    with pytest.raises(ValueError):
+        mock_session.get(MOCKED_URL)
+
+
 def test_remove_expired_responses__error(mock_session):
     # Start with two cached responses, one of which will raise an error
     mock_session.get(MOCKED_URL)


### PR DESCRIPTION
Backporting #763 for v0.9
Fixes #762