### PR TITLE
Fix `BaseCache.recreate_keys()` to normalize response bodies with `b'None'`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 ## 1.0.2 (2023-TBD)
 * Revert normalizing `CachedResponse.url` so it matches the original request URL
 * Fix loading cached JSON content when `decode_content=True` and the root element is a list
+* Fix `BaseCache.recreate_keys()` to normalize response bodies with `b'None'`
 * Add compatibility with urllib3 2.0
 
 ## 1.0.1 (2023-03-24)

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -228,6 +228,9 @@ class BaseCache:
 
         for old_cache_key in old_keys:
             response = self.responses[old_cache_key]
+            # Adjust empty request body for reponses cached before 1.0
+            if response.request.body == b'None':
+                response.request.body = b''
             new_cache_key = self.create_key(response.request)
             if new_cache_key != old_cache_key:
                 self.responses[new_cache_key] = response


### PR DESCRIPTION
Fixes #831