### PR TITLE
Use timezone-aware expiration datetimes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 * ⚠️ Remove methods [deprecated in 1.0](#deprecations-1-0) from `CachedSession` and `BaseCache`
 * Optimize `SQLiteCache.delete()` when deleting a single key
 * Add `vacuum` parameter to `SQLiteCache.delete()` to optionally skip vacuuming after deletion (enabled by default to free up disk space)
+* Use timezone-aware UTC datetimes for all internal expiration values
 
 ## 1.1.0 (2023-06-30)
 

--- a/examples/time_machine_backtesting.py
+++ b/examples/time_machine_backtesting.py
@@ -3,7 +3,7 @@
 An example of using the [time-machine](https://github.com/adamchainz/time-machine) library for backtesting,
 e.g., testing with cached responses that were available at an arbitrary time in the past.
 """
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 import requests
 import time_machine

--- a/examples/time_machine_backtesting.py
+++ b/examples/time_machine_backtesting.py
@@ -3,7 +3,7 @@
 An example of using the [time-machine](https://github.com/adamchainz/time-machine) library for backtesting,
 e.g., testing with cached responses that were available at an arbitrary time in the past.
 """
-from datetime import datetime
+from datetime import datetime, UTC
 
 import requests
 import time_machine
@@ -16,7 +16,7 @@ class BacktestCachedSession(CachedSession):
         response = super().request(method, url, **kwargs)
 
         # Response was cached after the (simulated) current time, so ignore it and send a new request
-        if response.created_at and response.created_at > datetime.utcnow():
+        if response.created_at and response.created_at > datetime.now(UTC):
             new_response = requests.request(method, url, **kwargs)
             return set_response_defaults(new_response)
         else:

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -190,8 +190,6 @@ def format_datetime(value: Optional[datetime]) -> str:
     """Get a formatted datetime string in the local time zone"""
     if not value:
         return "N/A"
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
     return value.astimezone().strftime(DATETIME_FORMAT)
 
 

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -11,7 +11,7 @@ from requests import PreparedRequest, Response
 from requests.cookies import RequestsCookieJar
 from requests.structures import CaseInsensitiveDict
 
-from ..policy import ExpirationTime, get_expiration_datetime, utcnow
+from ..policy import ExpirationTime, add_tzinfo, get_expiration_datetime, utcnow
 from . import CachedHTTPResponse, CachedRequest, RichMixin
 
 if TYPE_CHECKING:
@@ -69,7 +69,7 @@ class CachedResponse(RichMixin, BaseResponse):
     created_at: datetime = field(default=None)
     elapsed: timedelta = field(factory=timedelta)
     encoding: str = field(default=None)
-    expires: Optional[datetime] = field(default=None)
+    expires: Optional[datetime] = field(default=None, converter=add_tzinfo)
     headers: CaseInsensitiveDict = field(factory=CaseInsensitiveDict)
     history: List['CachedResponse'] = field(factory=list)  # type: ignore
     raw: CachedHTTPResponse = None  # type: ignore  # Not serialized; populated from CachedResponse attrs

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone, UTC
+from datetime import datetime, timedelta
 from logging import getLogger
 from time import time
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
@@ -11,7 +11,7 @@ from requests import PreparedRequest, Response
 from requests.cookies import RequestsCookieJar
 from requests.structures import CaseInsensitiveDict
 
-from ..policy import ExpirationTime, get_expiration_datetime
+from ..policy import ExpirationTime, get_expiration_datetime, utcnow
 from . import CachedHTTPResponse, CachedRequest, RichMixin
 
 if TYPE_CHECKING:
@@ -28,7 +28,7 @@ class BaseResponse(Response):
     provide type hints for extra cache-related attributes that are added to non-cached responses.
     """
 
-    created_at: datetime = field(factory=lambda: datetime.now(UTC))
+    created_at: datetime = field(factory=utcnow)
     expires: Optional[datetime] = field(default=None)
     cache_key: str = ''  # Not serialized; set by BaseCache.get_response()
     revalidated: bool = False  # Not serialized; set by CacheActions.update_revalidated_response()
@@ -54,7 +54,7 @@ class OriginalResponse(BaseResponse):
             # Add expires and cache_key only if the response was written to the cache
             response.expires = None if actions.skip_write else actions.expires  # type: ignore
             response.cache_key = None if actions.skip_write else actions.cache_key  # type: ignore
-            response.created_at = datetime.now(UTC)  # type: ignore
+            response.created_at = utcnow()  # type: ignore
         return response  # type: ignore
 
 
@@ -80,7 +80,7 @@ class CachedResponse(RichMixin, BaseResponse):
 
     def __attrs_post_init__(self):
         # Not using created_at field default due to possible bug on Windows with omit_if_default
-        self.created_at = self.created_at or datetime.now(UTC)
+        self.created_at = self.created_at or utcnow()
         # Re-initialize raw (urllib3) response after deserialization
         self.raw = self.raw or CachedHTTPResponse.from_cached_response(self)
 
@@ -130,7 +130,7 @@ class CachedResponse(RichMixin, BaseResponse):
         """Get time to expiration in seconds (rounded to the nearest second)"""
         if self.expires is None:
             return None
-        delta = self.expires - datetime.now(UTC)
+        delta = self.expires - utcnow()
         return round(delta.total_seconds())
 
     @property
@@ -146,7 +146,7 @@ class CachedResponse(RichMixin, BaseResponse):
     @property
     def is_expired(self) -> bool:
         """Determine if this cached response is expired"""
-        return self.expires is not None and datetime.now(UTC) >= self.expires
+        return self.expires is not None and utcnow() >= self.expires
 
     def is_older_than(self, older_than: ExpirationTime) -> bool:
         """Determine if this cached response is older than the given time"""

--- a/requests_cache/policy/actions.py
+++ b/requests_cache/policy/actions.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from logging import DEBUG, getLogger
 from typing import TYPE_CHECKING, Dict, List, MutableMapping, Optional, Union
 
@@ -163,7 +163,7 @@ class CacheActions(RichMixin):
         else:
             offset = self._directives.get_expire_offset()
 
-        return datetime.utcnow() < cached_response.expires + offset
+        return datetime.now(UTC) < cached_response.expires + offset
 
     def update_from_cached_response(
         self,

--- a/requests_cache/policy/actions.py
+++ b/requests_cache/policy/actions.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta
 from logging import DEBUG, getLogger
 from typing import TYPE_CHECKING, Dict, List, MutableMapping, Optional, Union
 
@@ -18,6 +18,7 @@ from . import (
     get_expiration_datetime,
     get_expiration_seconds,
     get_url_expiration,
+    utcnow,
 )
 from .settings import CacheSettings
 
@@ -163,7 +164,7 @@ class CacheActions(RichMixin):
         else:
             offset = self._directives.get_expire_offset()
 
-        return datetime.now(UTC) < cached_response.expires + offset
+        return utcnow() < cached_response.expires + offset
 
     def update_from_cached_response(
         self,

--- a/requests_cache/policy/expiration.py
+++ b/requests_cache/policy/expiration.py
@@ -1,5 +1,5 @@
 """Utility functions for parsing and converting expiration values"""
-from datetime import datetime, timedelta, timezone, UTC
+from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 from fnmatch import fnmatch
 from logging import getLogger
@@ -30,7 +30,7 @@ def get_expiration_datetime(
         return None
     # Expire immediately
     elif try_int(expire_after) == EXPIRE_IMMEDIATELY:
-        return start_time or datetime.now(UTC)
+        return start_time or utcnow()
     # Already a datetime or httpdate str (allowed for headers only)
     if isinstance(expire_after, str):
         expire_after_dt = _parse_http_date(expire_after)
@@ -45,7 +45,7 @@ def get_expiration_datetime(
         expire_after = timedelta(seconds=expire_after)
     if negative_delta:
         expire_after = -expire_after
-    return (start_time or datetime.now(UTC)) + expire_after
+    return (start_time or utcnow()) + expire_after
 
 
 def get_expiration_seconds(expire_after: ExpirationTime) -> int:
@@ -53,7 +53,7 @@ def get_expiration_seconds(expire_after: ExpirationTime) -> int:
     if expire_after == DO_NOT_CACHE:
         return DO_NOT_CACHE
     expires = get_expiration_datetime(expire_after, ignore_invalid_httpdate=True)
-    return ceil((expires - datetime.now(UTC)).total_seconds()) if expires else NEVER_EXPIRE
+    return ceil((expires - utcnow()).total_seconds()) if expires else NEVER_EXPIRE
 
 
 def get_url_expiration(
@@ -68,6 +68,11 @@ def get_url_expiration(
             logger.debug(f'URL {url} matched pattern "{pattern}": {expire_after}')
             return expire_after
     return None
+
+
+def utcnow() -> datetime:
+    """Get the current time in UTC (timezone-aware)"""
+    return datetime.now(timezone.utc)
 
 
 def _parse_http_date(value: str) -> Optional[datetime]:

--- a/requests_cache/policy/expiration.py
+++ b/requests_cache/policy/expiration.py
@@ -70,6 +70,15 @@ def get_url_expiration(
     return None
 
 
+def add_tzinfo(dt: Optional[datetime]) -> Optional[datetime]:
+    """Add a UTC timezone to a datetime object, if it doesn't already have one. This is used mainly
+    during deserialization for backends that don't store timezone info.
+    """
+    if dt and dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 def utcnow() -> datetime:
     """Get the current time in UTC (timezone-aware)"""
     return datetime.now(timezone.utc)

--- a/requests_cache/policy/expiration.py
+++ b/requests_cache/policy/expiration.py
@@ -1,5 +1,5 @@
 """Utility functions for parsing and converting expiration values"""
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from email.utils import parsedate_to_datetime
 from fnmatch import fnmatch
 from logging import getLogger
@@ -30,7 +30,7 @@ def get_expiration_datetime(
         return None
     # Expire immediately
     elif try_int(expire_after) == EXPIRE_IMMEDIATELY:
-        return start_time or datetime.utcnow()
+        return start_time or datetime.now(UTC)
     # Already a datetime or httpdate str (allowed for headers only)
     if isinstance(expire_after, str):
         expire_after_dt = _parse_http_date(expire_after)
@@ -45,7 +45,7 @@ def get_expiration_datetime(
         expire_after = timedelta(seconds=expire_after)
     if negative_delta:
         expire_after = -expire_after
-    return (start_time or datetime.utcnow()) + expire_after
+    return (start_time or datetime.now(UTC)) + expire_after
 
 
 def get_expiration_seconds(expire_after: ExpirationTime) -> int:
@@ -53,7 +53,7 @@ def get_expiration_seconds(expire_after: ExpirationTime) -> int:
     if expire_after == DO_NOT_CACHE:
         return DO_NOT_CACHE
     expires = get_expiration_datetime(expire_after, ignore_invalid_httpdate=True)
-    return ceil((expires - datetime.utcnow()).total_seconds()) if expires else NEVER_EXPIRE
+    return ceil((expires - datetime.now(UTC)).total_seconds()) if expires else NEVER_EXPIRE
 
 
 def get_url_expiration(

--- a/requests_cache/policy/expiration.py
+++ b/requests_cache/policy/expiration.py
@@ -38,7 +38,7 @@ def get_expiration_datetime(
             raise ValueError(f'Invalid HTTP date: {expire_after}')
         return expire_after_dt
     elif isinstance(expire_after, datetime):
-        return _to_utc(expire_after)
+        return expire_after.astimezone(timezone.utc)
 
     # Otherwise, it must be a timedelta or time in seconds
     if not isinstance(expire_after, timedelta):
@@ -79,20 +79,10 @@ def _parse_http_date(value: str) -> Optional[datetime]:
     """Attempt to parse an HTTP (RFC 5322-compatible) timestamp"""
     try:
         expire_after = parsedate_to_datetime(value)
-        return _to_utc(expire_after)
+        return expire_after.astimezone(timezone.utc)
     except (TypeError, ValueError):
         logger.debug(f'Failed to parse timestamp: {value}')
         return None
-
-
-def _to_utc(dt: datetime):
-    """All internal datetimes are UTC and timezone-naive. Convert any user/header-provided
-    datetimes to the same format.
-    """
-    if dt.tzinfo:
-        dt = dt.astimezone(timezone.utc)
-        dt = dt.replace(tzinfo=None)
-    return dt
 
 
 def _url_match(url: str, pattern: ExpirationPattern) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import os
 import platform
 import warnings
 from contextlib import contextmanager, nullcontext
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from functools import wraps
 from importlib import import_module
 from logging import basicConfig, getLogger
@@ -72,11 +72,11 @@ HTTPBIN_FORMATS = [
 ]
 HTTPDATE_STR = 'Fri, 16 APR 2021 21:13:00 GMT'
 HTTPDATE_DATETIME = datetime(2021, 4, 16, 21, 13)
-EXPIRED_DT = datetime.utcnow() - timedelta(1)
+EXPIRED_DT = datetime.now(UTC) - timedelta(1)
 ETAG = '"644b5b0155e6404a9cc4bd9d8b1ae730"'
 LAST_MODIFIED = 'Thu, 05 Jul 2012 15:31:30 GMT'
-START_DT = datetime.utcnow()
-YESTERDAY = datetime.utcnow() - timedelta(days=1)
+START_DT = datetime.now(UTC)
+YESTERDAY = datetime.now(UTC) - timedelta(days=1)
 
 MOCKED_URL = 'http+mock://requests-cache.com/text'
 MOCKED_URL_ETAG = 'http+mock://requests-cache.com/etag'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import os
 import platform
 import warnings
 from contextlib import contextmanager, nullcontext
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta
 from functools import wraps
 from importlib import import_module
 from logging import basicConfig, getLogger
@@ -28,7 +28,7 @@ from requests_mock import Adapter
 from rich.logging import RichHandler
 from timeout_decorator import timeout
 
-from requests_cache import ALL_METHODS, CachedSession, install_cache, uninstall_cache
+from requests_cache import ALL_METHODS, CachedSession, install_cache, uninstall_cache, utcnow
 
 # ignore missing time-travel library on PyPy
 try:
@@ -72,11 +72,11 @@ HTTPBIN_FORMATS = [
 ]
 HTTPDATE_STR = 'Fri, 16 APR 2021 21:13:00 GMT'
 HTTPDATE_DATETIME = datetime(2021, 4, 16, 21, 13)
-EXPIRED_DT = datetime.now(UTC) - timedelta(1)
+EXPIRED_DT = utcnow() - timedelta(1)
 ETAG = '"644b5b0155e6404a9cc4bd9d8b1ae730"'
 LAST_MODIFIED = 'Thu, 05 Jul 2012 15:31:30 GMT'
-START_DT = datetime.now(UTC)
-YESTERDAY = datetime.now(UTC) - timedelta(days=1)
+START_DT = utcnow()
+YESTERDAY = utcnow() - timedelta(days=1)
 
 MOCKED_URL = 'http+mock://requests-cache.com/text'
 MOCKED_URL_ETAG = 'http+mock://requests-cache.com/etag'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import os
 import platform
 import warnings
 from contextlib import contextmanager, nullcontext
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import wraps
 from importlib import import_module
 from logging import basicConfig, getLogger
@@ -71,7 +71,7 @@ HTTPBIN_FORMATS = [
     'xml',
 ]
 HTTPDATE_STR = 'Fri, 16 APR 2021 21:13:00 GMT'
-HTTPDATE_DATETIME = datetime(2021, 4, 16, 21, 13)
+HTTPDATE_DATETIME = datetime(2021, 4, 16, 21, 13, tzinfo=timezone.utc)
 EXPIRED_DT = utcnow() - timedelta(1)
 ETAG = '"644b5b0155e6404a9cc4bd9d8b1ae730"'
 LAST_MODIFIED = 'Thu, 05 Jul 2012 15:31:30 GMT'

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -1,7 +1,7 @@
 """Common tests to run for all backends (BaseCache subclasses)"""
 import json
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, UTC
 from functools import partial
 from io import BytesIO
 from logging import getLogger
@@ -180,7 +180,7 @@ class BaseCacheTest:
         if expected_expiration is None:
             assert response.expires is None
         else:
-            assert_delta_approx_equal(datetime.utcnow(), response.expires, expected_expiration)
+            assert_delta_approx_equal(datetime.now(UTC), response.expires, expected_expiration)
 
     @pytest.mark.parametrize(
         'cached_response_headers, expected_from_cache',

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -1,7 +1,6 @@
 """Common tests to run for all backends (BaseCache subclasses)"""
 import json
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
-from datetime import datetime, UTC
 from functools import partial
 from io import BytesIO
 from logging import getLogger
@@ -17,6 +16,7 @@ from requests import ConnectionError, PreparedRequest, Session
 
 from requests_cache import ALL_METHODS, CachedResponse, CachedSession
 from requests_cache.backends import BaseCache
+from requests_cache.policy import utcnow
 from tests.conftest import (
     CACHE_NAME,
     ETAG,
@@ -180,7 +180,7 @@ class BaseCacheTest:
         if expected_expiration is None:
             assert response.expires is None
         else:
-            assert_delta_approx_equal(datetime.now(UTC), response.expires, expected_expiration)
+            assert_delta_approx_equal(utcnow(), response.expires, expected_expiration)
 
     @pytest.mark.parametrize(
         'cached_response_headers, expected_from_cache',

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from os.path import join
 from tempfile import NamedTemporaryFile, gettempdir
 from threading import Thread
@@ -256,7 +256,7 @@ class TestSQLiteDict(BaseStorageTest):
     @pytest.mark.parametrize('limit', [None, 50])
     def test_sorted__by_expires(self, limit):
         cache = self.init_cache()
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         # Insert items with decreasing expiration time
         for i in range(100):
@@ -274,7 +274,7 @@ class TestSQLiteDict(BaseStorageTest):
     @skip_pypy
     def test_sorted__exclude_expired(self):
         cache = self.init_cache()
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         # Make only odd numbered items expired
         for i in range(100):
@@ -375,7 +375,7 @@ class TestSQLiteCache(BaseCacheTest):
     def test_count(self):
         """count() should work the same as len(), but with the option to exclude expired responses"""
         session = self.init_session()
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         session.cache.responses['key_1'] = CachedResponse(expires=now + timedelta(1))
         session.cache.responses['key_2'] = CachedResponse(expires=now - timedelta(1))
 
@@ -415,7 +415,7 @@ class TestSQLiteCache(BaseCacheTest):
     def test_sorted(self):
         """Test wrapper method for SQLiteDict.sorted(), with all arguments combined"""
         session = self.init_session(clear=False)
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
         # Insert items with decreasing expiration time
         for i in range(500):

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 import sqlite3
-from datetime import datetime, timedelta, UTC
+from datetime import timedelta
 from os.path import join
 from tempfile import NamedTemporaryFile, gettempdir
 from threading import Thread
@@ -13,6 +13,7 @@ from platformdirs import user_cache_dir
 from requests_cache.backends import BaseCache, SQLiteCache, SQLiteDict
 from requests_cache.backends.sqlite import MEMORY_URI
 from requests_cache.models import CachedResponse
+from requests_cache.policy import utcnow
 from tests.conftest import skip_pypy
 from tests.integration.base_cache_test import BaseCacheTest
 from tests.integration.base_storage_test import CACHE_NAME, BaseStorageTest
@@ -256,7 +257,7 @@ class TestSQLiteDict(BaseStorageTest):
     @pytest.mark.parametrize('limit', [None, 50])
     def test_sorted__by_expires(self, limit):
         cache = self.init_cache()
-        now = datetime.now(UTC)
+        now = utcnow()
 
         # Insert items with decreasing expiration time
         for i in range(100):
@@ -274,7 +275,7 @@ class TestSQLiteDict(BaseStorageTest):
     @skip_pypy
     def test_sorted__exclude_expired(self):
         cache = self.init_cache()
-        now = datetime.now(UTC)
+        now = utcnow()
 
         # Make only odd numbered items expired
         for i in range(100):
@@ -375,7 +376,7 @@ class TestSQLiteCache(BaseCacheTest):
     def test_count(self):
         """count() should work the same as len(), but with the option to exclude expired responses"""
         session = self.init_session()
-        now = datetime.now(UTC)
+        now = utcnow()
         session.cache.responses['key_1'] = CachedResponse(expires=now + timedelta(1))
         session.cache.responses['key_2'] = CachedResponse(expires=now - timedelta(1))
 
@@ -415,7 +416,7 @@ class TestSQLiteCache(BaseCacheTest):
     def test_sorted(self):
         """Test wrapper method for SQLiteDict.sorted(), with all arguments combined"""
         session = self.init_session(clear=False)
-        now = datetime.now(UTC)
+        now = utcnow()
 
         # Insert items with decreasing expiration time
         for i in range(500):

--- a/tests/unit/models/test_response.py
+++ b/tests/unit/models/test_response.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, UTC
+from datetime import timedelta
 from io import BytesIO
 from time import sleep
 
@@ -6,6 +6,7 @@ import pytest
 from urllib3.response import HTTPResponse
 
 from requests_cache.models.response import CachedResponse, format_file_size
+from requests_cache.policy import utcnow
 from tests.conftest import MOCKED_URL
 
 
@@ -35,8 +36,8 @@ def test_history(mock_session):
 @pytest.mark.parametrize(
     'expires, is_expired',
     [
-        (datetime.now(UTC) + timedelta(days=1), False),
-        (datetime.now(UTC) - timedelta(days=1), True),
+        (utcnow() + timedelta(days=1), False),
+        (utcnow() - timedelta(days=1), True),
     ],
 )
 def test_is_expired(expires, is_expired, mock_session):
@@ -79,12 +80,12 @@ def test_reset_expiration__extend_expiration(mock_session):
     # Start with an expired response
     response = CachedResponse.from_response(
         mock_session.get(MOCKED_URL),
-        expires=datetime.now(UTC) - timedelta(seconds=0.01),
+        expires=utcnow() - timedelta(seconds=0.01),
     )
     assert response.is_expired is True
 
     # Set expiration in the future
-    is_expired = response.reset_expiration(datetime.now(UTC) + timedelta(seconds=0.01))
+    is_expired = response.reset_expiration(utcnow() + timedelta(seconds=0.01))
     assert is_expired is response.is_expired is False
     sleep(0.1)
     assert response.is_expired is True
@@ -94,12 +95,12 @@ def test_reset_expiration__shorten_expiration(mock_session):
     # Start with a non-expired response
     response = CachedResponse.from_response(
         mock_session.get(MOCKED_URL),
-        expires=datetime.now(UTC) + timedelta(seconds=1),
+        expires=utcnow() + timedelta(seconds=1),
     )
     assert response.is_expired is False
 
     # Set expiration in the past
-    is_expired = response.reset_expiration(datetime.now(UTC) - timedelta(seconds=1))
+    is_expired = response.reset_expiration(utcnow() - timedelta(seconds=1))
     assert is_expired is response.is_expired is True
 
 

--- a/tests/unit/models/test_response.py
+++ b/tests/unit/models/test_response.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from io import BytesIO
 from time import sleep
 
@@ -35,8 +35,8 @@ def test_history(mock_session):
 @pytest.mark.parametrize(
     'expires, is_expired',
     [
-        (datetime.utcnow() + timedelta(days=1), False),
-        (datetime.utcnow() - timedelta(days=1), True),
+        (datetime.now(UTC) + timedelta(days=1), False),
+        (datetime.now(UTC) - timedelta(days=1), True),
     ],
 )
 def test_is_expired(expires, is_expired, mock_session):
@@ -79,12 +79,12 @@ def test_reset_expiration__extend_expiration(mock_session):
     # Start with an expired response
     response = CachedResponse.from_response(
         mock_session.get(MOCKED_URL),
-        expires=datetime.utcnow() - timedelta(seconds=0.01),
+        expires=datetime.now(UTC) - timedelta(seconds=0.01),
     )
     assert response.is_expired is True
 
     # Set expiration in the future
-    is_expired = response.reset_expiration(datetime.utcnow() + timedelta(seconds=0.01))
+    is_expired = response.reset_expiration(datetime.now(UTC) + timedelta(seconds=0.01))
     assert is_expired is response.is_expired is False
     sleep(0.1)
     assert response.is_expired is True
@@ -94,12 +94,12 @@ def test_reset_expiration__shorten_expiration(mock_session):
     # Start with a non-expired response
     response = CachedResponse.from_response(
         mock_session.get(MOCKED_URL),
-        expires=datetime.utcnow() + timedelta(seconds=1),
+        expires=datetime.now(UTC) + timedelta(seconds=1),
     )
     assert response.is_expired is False
 
     # Set expiration in the past
-    is_expired = response.reset_expiration(datetime.utcnow() - timedelta(seconds=1))
+    is_expired = response.reset_expiration(datetime.now(UTC) - timedelta(seconds=1))
     assert is_expired is response.is_expired is True
 
 

--- a/tests/unit/policy/test_actions.py
+++ b/tests/unit/policy/test_actions.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from unittest.mock import patch
 
 import pytest
@@ -18,7 +18,7 @@ IGNORED_DIRECTIVES = [
     's-maxage=<seconds>',
 ]
 BASIC_REQUEST = Request(method='GET', url='https://site.com/img.jpg', headers={})
-EXPIRED_RESPONSE = CachedResponse(expires=datetime.utcnow() - timedelta(1))
+EXPIRED_RESPONSE = CachedResponse(expires=datetime.now(UTC) - timedelta(1))
 
 
 @pytest.mark.parametrize(
@@ -175,7 +175,7 @@ def test_update_from_cached_response__revalidate(response_headers, expected_vali
     """Conditional request headers should be added if the cached response is expired"""
     actions = CacheActions.from_request('key', BASIC_REQUEST)
     cached_response = CachedResponse(
-        headers=response_headers, expires=datetime.utcnow() - timedelta(1)
+        headers=response_headers, expires=datetime.now(UTC) - timedelta(1)
     )
 
     actions.update_from_cached_response(cached_response)
@@ -335,7 +335,7 @@ def test_is_usable__max_stale(max_stale, usable):
         headers={'Cache-Control': f'max-stale={max_stale}'},
     )
     actions = CacheActions.from_request('key', request)
-    cached_response = CachedResponse(expires=datetime.utcnow() - timedelta(seconds=10))
+    cached_response = CachedResponse(expires=datetime.now(UTC) - timedelta(seconds=10))
     assert actions.is_usable(cached_response) is usable
 
 
@@ -349,7 +349,7 @@ def test_is_usable__min_fresh(min_fresh, usable):
         headers={'Cache-Control': f'min-fresh={min_fresh}'},
     )
     actions = CacheActions.from_request('key', request)
-    cached_response = CachedResponse(expires=datetime.utcnow() + timedelta(seconds=10))
+    cached_response = CachedResponse(expires=datetime.now(UTC) + timedelta(seconds=10))
     assert actions.is_usable(cached_response) is usable
 
 
@@ -370,7 +370,7 @@ def test_is_usable__stale_if_error(stale_if_error, error, usable):
         headers={'Cache-Control': f'stale-if-error={stale_if_error}'},
     )
     actions = CacheActions.from_request('key', request)
-    cached_response = CachedResponse(expires=datetime.utcnow() - timedelta(seconds=10))
+    cached_response = CachedResponse(expires=datetime.now(UTC) - timedelta(seconds=10))
     assert actions.is_usable(cached_response, error=error) is usable
 
 
@@ -390,7 +390,7 @@ def test_is_usable__stale_while_revalidate(stale_while_revalidate, usable):
         headers={'Cache-Control': f'stale-while-revalidate={stale_while_revalidate}'},
     )
     actions = CacheActions.from_request('key', request)
-    cached_response = CachedResponse(expires=datetime.utcnow() - timedelta(seconds=10))
+    cached_response = CachedResponse(expires=datetime.now(UTC) - timedelta(seconds=10))
     assert actions.is_usable(cached_response=cached_response) is usable
 
 
@@ -441,7 +441,7 @@ def test_update_from_response__revalidate(mock_datetime, cache_headers, validato
     response = get_mock_response(headers={**cache_headers, **validator_headers})
     actions.update_from_response(response)
 
-    assert actions.expires == mock_datetime.utcnow()
+    assert actions.expires == mock_datetime.now(UTC)
     assert actions.skip_write is False
 
 

--- a/tests/unit/policy/test_actions.py
+++ b/tests/unit/policy/test_actions.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, UTC
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -6,8 +6,7 @@ from requests import PreparedRequest, Request
 
 from requests_cache.cache_keys import create_key
 from requests_cache.models import CachedResponse
-from requests_cache.policy.actions import EXPIRE_IMMEDIATELY, CacheActions
-from requests_cache.policy.settings import CacheSettings
+from requests_cache.policy import EXPIRE_IMMEDIATELY, CacheActions, CacheSettings, utcnow
 from tests.conftest import ETAG, HTTPDATE_STR, LAST_MODIFIED, MOCKED_URL, get_mock_response
 
 IGNORED_DIRECTIVES = [
@@ -18,7 +17,7 @@ IGNORED_DIRECTIVES = [
     's-maxage=<seconds>',
 ]
 BASIC_REQUEST = Request(method='GET', url='https://site.com/img.jpg', headers={})
-EXPIRED_RESPONSE = CachedResponse(expires=datetime.now(UTC) - timedelta(1))
+EXPIRED_RESPONSE = CachedResponse(expires=utcnow() - timedelta(1))
 
 
 @pytest.mark.parametrize(
@@ -174,9 +173,7 @@ def test_update_from_cached_response__resend_request():
 def test_update_from_cached_response__revalidate(response_headers, expected_validation_headers):
     """Conditional request headers should be added if the cached response is expired"""
     actions = CacheActions.from_request('key', BASIC_REQUEST)
-    cached_response = CachedResponse(
-        headers=response_headers, expires=datetime.now(UTC) - timedelta(1)
-    )
+    cached_response = CachedResponse(headers=response_headers, expires=utcnow() - timedelta(1))
 
     actions.update_from_cached_response(cached_response)
     assert actions.send_request is bool(expected_validation_headers)
@@ -335,7 +332,7 @@ def test_is_usable__max_stale(max_stale, usable):
         headers={'Cache-Control': f'max-stale={max_stale}'},
     )
     actions = CacheActions.from_request('key', request)
-    cached_response = CachedResponse(expires=datetime.now(UTC) - timedelta(seconds=10))
+    cached_response = CachedResponse(expires=utcnow() - timedelta(seconds=10))
     assert actions.is_usable(cached_response) is usable
 
 
@@ -349,7 +346,7 @@ def test_is_usable__min_fresh(min_fresh, usable):
         headers={'Cache-Control': f'min-fresh={min_fresh}'},
     )
     actions = CacheActions.from_request('key', request)
-    cached_response = CachedResponse(expires=datetime.now(UTC) + timedelta(seconds=10))
+    cached_response = CachedResponse(expires=utcnow() + timedelta(seconds=10))
     assert actions.is_usable(cached_response) is usable
 
 
@@ -370,7 +367,7 @@ def test_is_usable__stale_if_error(stale_if_error, error, usable):
         headers={'Cache-Control': f'stale-if-error={stale_if_error}'},
     )
     actions = CacheActions.from_request('key', request)
-    cached_response = CachedResponse(expires=datetime.now(UTC) - timedelta(seconds=10))
+    cached_response = CachedResponse(expires=utcnow() - timedelta(seconds=10))
     assert actions.is_usable(cached_response, error=error) is usable
 
 
@@ -390,7 +387,7 @@ def test_is_usable__stale_while_revalidate(stale_while_revalidate, usable):
         headers={'Cache-Control': f'stale-while-revalidate={stale_while_revalidate}'},
     )
     actions = CacheActions.from_request('key', request)
-    cached_response = CachedResponse(expires=datetime.now(UTC) - timedelta(seconds=10))
+    cached_response = CachedResponse(expires=utcnow() - timedelta(seconds=10))
     assert actions.is_usable(cached_response=cached_response) is usable
 
 
@@ -432,8 +429,8 @@ def test_update_from_response__ignored():
 
 @pytest.mark.parametrize('validator_headers', [{'ETag': ETAG}, {'Last-Modified': LAST_MODIFIED}])
 @pytest.mark.parametrize('cache_headers', [{'Cache-Control': 'max-age=0'}, {'Expires': '0'}])
-@patch('requests_cache.expiration.datetime')
-def test_update_from_response__revalidate(mock_datetime, cache_headers, validator_headers):
+@patch('requests_cache.expiration.utcnow')
+def test_update_from_response__revalidate(mock_utcnow, cache_headers, validator_headers):
     """If expiration is 0 and there's a validator, the response should be cached, but with immediate
     expiration
     """
@@ -441,7 +438,7 @@ def test_update_from_response__revalidate(mock_datetime, cache_headers, validato
     response = get_mock_response(headers={**cache_headers, **validator_headers})
     actions.update_from_response(response)
 
-    assert actions.expires == mock_datetime.now(UTC)
+    assert actions.expires == mock_utcnow()
     assert actions.skip_write is False
 
 

--- a/tests/unit/policy/test_expiration.py
+++ b/tests/unit/policy/test_expiration.py
@@ -38,7 +38,7 @@ def test_get_expiration_datetime__relative(expire_after, expected_expiration_del
 def test_get_expiration_datetime__tzinfo():
     tz = timezone(-timedelta(hours=5))
     dt = datetime(2021, 2, 1, 7, 0, tzinfo=tz)
-    assert get_expiration_datetime(dt) == datetime(2021, 2, 1, 12, 0)
+    assert get_expiration_datetime(dt) == datetime(2021, 2, 1, 12, 0, tzinfo=timezone.utc)
 
 
 def test_get_expiration_datetime__httpdate():

--- a/tests/unit/policy/test_expiration.py
+++ b/tests/unit/policy/test_expiration.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, timedelta, timezone, UTC
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -8,6 +8,7 @@ from requests_cache.policy.expiration import (
     EXPIRE_IMMEDIATELY,
     get_expiration_datetime,
     get_url_expiration,
+    utcnow,
 )
 from tests.conftest import HTTPDATE_DATETIME, HTTPDATE_STR
 
@@ -16,7 +17,7 @@ from tests.conftest import HTTPDATE_DATETIME, HTTPDATE_STR
 def test_get_expiration_datetime__no_expiration(mock_datetime):
     assert get_expiration_datetime(None) is None
     assert get_expiration_datetime(-1) is None
-    assert get_expiration_datetime(EXPIRE_IMMEDIATELY) == mock_datetime.now(UTC)
+    assert get_expiration_datetime(EXPIRE_IMMEDIATELY) == mock_datetime.now(timezone.utc)
 
 
 @pytest.mark.parametrize(
@@ -29,7 +30,7 @@ def test_get_expiration_datetime__no_expiration(mock_datetime):
 )
 def test_get_expiration_datetime__relative(expire_after, expected_expiration_delta):
     expires = get_expiration_datetime(expire_after)
-    expected_expiration = datetime.now(UTC) + expected_expiration_delta
+    expected_expiration = utcnow() + expected_expiration_delta
     # Instead of mocking datetime (which adds some complications), check for approximate value
     assert abs((expires - expected_expiration).total_seconds()) <= 1
 

--- a/tests/unit/policy/test_expiration.py
+++ b/tests/unit/policy/test_expiration.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from unittest.mock import patch
 
 import pytest
@@ -16,7 +16,7 @@ from tests.conftest import HTTPDATE_DATETIME, HTTPDATE_STR
 def test_get_expiration_datetime__no_expiration(mock_datetime):
     assert get_expiration_datetime(None) is None
     assert get_expiration_datetime(-1) is None
-    assert get_expiration_datetime(EXPIRE_IMMEDIATELY) == mock_datetime.utcnow()
+    assert get_expiration_datetime(EXPIRE_IMMEDIATELY) == mock_datetime.now(UTC)
 
 
 @pytest.mark.parametrize(
@@ -29,7 +29,7 @@ def test_get_expiration_datetime__no_expiration(mock_datetime):
 )
 def test_get_expiration_datetime__relative(expire_after, expected_expiration_delta):
     expires = get_expiration_datetime(expire_after)
-    expected_expiration = datetime.utcnow() + expected_expiration_delta
+    expected_expiration = datetime.now(UTC) + expected_expiration_delta
     # Instead of mocking datetime (which adds some complications), check for approximate value
     assert abs((expires - expected_expiration).total_seconds()) <= 1
 

--- a/tests/unit/test_base_cache.py
+++ b/tests/unit/test_base_cache.py
@@ -1,6 +1,6 @@
 """BaseCache tests that use mocked responses only"""
 import pickle
-from datetime import datetime, timedelta, UTC
+from datetime import timedelta
 from logging import getLogger
 from pickle import PickleError
 from unittest.mock import patch
@@ -11,6 +11,7 @@ from requests import Request
 from requests_cache.backends import BaseCache, SQLiteCache, SQLiteDict
 from requests_cache.cache_keys import create_key
 from requests_cache.models import CachedRequest, CachedResponse
+from requests_cache.policy import utcnow
 from requests_cache.session import CachedSession
 from tests.conftest import (
     MOCKED_URL,
@@ -277,11 +278,11 @@ def test_recreate_keys__empty_response_body(mock_session):
 
 def test_reset_expiration__extend_expiration(mock_session):
     # Start with an expired response
-    mock_session.settings.expire_after = datetime.now(UTC) - timedelta(seconds=1)
+    mock_session.settings.expire_after = utcnow() - timedelta(seconds=1)
     mock_session.get(MOCKED_URL)
 
     # Set expiration in the future
-    mock_session.cache.reset_expiration(datetime.now(UTC) + timedelta(seconds=1))
+    mock_session.cache.reset_expiration(utcnow() + timedelta(seconds=1))
     assert len(mock_session.cache.responses) == 1
     response = mock_session.get(MOCKED_URL)
     assert response.is_expired is False and response.from_cache is True
@@ -289,11 +290,11 @@ def test_reset_expiration__extend_expiration(mock_session):
 
 def test_reset_expiration__shorten_expiration(mock_session):
     # Start with a non-expired response
-    mock_session.settings.expire_after = datetime.now(UTC) + timedelta(seconds=1)
+    mock_session.settings.expire_after = utcnow() + timedelta(seconds=1)
     mock_session.get(MOCKED_URL)
 
     # Set expiration in the past
-    mock_session.cache.reset_expiration(datetime.now(UTC) - timedelta(seconds=1))
+    mock_session.cache.reset_expiration(utcnow() - timedelta(seconds=1))
     response = mock_session.get(MOCKED_URL)
     assert response.is_expired is False and response.from_cache is False
 

--- a/tests/unit/test_base_cache.py
+++ b/tests/unit/test_base_cache.py
@@ -1,6 +1,6 @@
 """BaseCache tests that use mocked responses only"""
 import pickle
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from logging import getLogger
 from pickle import PickleError
 from unittest.mock import patch
@@ -277,11 +277,11 @@ def test_recreate_keys__empty_response_body(mock_session):
 
 def test_reset_expiration__extend_expiration(mock_session):
     # Start with an expired response
-    mock_session.settings.expire_after = datetime.utcnow() - timedelta(seconds=1)
+    mock_session.settings.expire_after = datetime.now(UTC) - timedelta(seconds=1)
     mock_session.get(MOCKED_URL)
 
     # Set expiration in the future
-    mock_session.cache.reset_expiration(datetime.utcnow() + timedelta(seconds=1))
+    mock_session.cache.reset_expiration(datetime.now(UTC) + timedelta(seconds=1))
     assert len(mock_session.cache.responses) == 1
     response = mock_session.get(MOCKED_URL)
     assert response.is_expired is False and response.from_cache is True
@@ -289,11 +289,11 @@ def test_reset_expiration__extend_expiration(mock_session):
 
 def test_reset_expiration__shorten_expiration(mock_session):
     # Start with a non-expired response
-    mock_session.settings.expire_after = datetime.utcnow() + timedelta(seconds=1)
+    mock_session.settings.expire_after = datetime.now(UTC) + timedelta(seconds=1)
     mock_session.get(MOCKED_URL)
 
     # Set expiration in the past
-    mock_session.cache.reset_expiration(datetime.utcnow() - timedelta(seconds=1))
+    mock_session.cache.reset_expiration(datetime.now(UTC) - timedelta(seconds=1))
     response = mock_session.get(MOCKED_URL)
     assert response.is_expired is False and response.from_cache is False
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -2,7 +2,7 @@
 import json
 import pickle
 from collections import UserDict, defaultdict
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta
 from logging import getLogger
 from pathlib import Path
 from pickle import PickleError
@@ -20,7 +20,7 @@ from requests_cache._utils import get_placeholder_class
 from requests_cache.backends import BACKEND_CLASSES, BaseCache
 from requests_cache.backends.base import DESERIALIZE_ERRORS
 from requests_cache.models import CachedResponse
-from requests_cache.policy.expiration import DO_NOT_CACHE, EXPIRE_IMMEDIATELY, NEVER_EXPIRE
+from requests_cache.policy import DO_NOT_CACHE, EXPIRE_IMMEDIATELY, NEVER_EXPIRE, utcnow
 from tests.conftest import (
     MOCKED_URL,
     MOCKED_URL_200_404,
@@ -91,7 +91,7 @@ def test_pickle__disabled():
 
 def test_response_defaults(mock_session):
     """Both cached and new responses should always have the following attributes"""
-    mock_session.settings.expire_after = datetime.now(UTC) + timedelta(days=1)
+    mock_session.settings.expire_after = utcnow() + timedelta(days=1)
     response_1 = mock_session.get(MOCKED_URL)
     response_2 = mock_session.get(MOCKED_URL)
     response_3 = mock_session.get(MOCKED_URL)
@@ -472,7 +472,7 @@ def test_stale_if_error__max_stale(mock_session):
     status code AND it is expired by less than the specified time
     """
     mock_session.settings.stale_if_error = timedelta(seconds=15)
-    mock_session.settings.expire_after = datetime.now(UTC) - timedelta(seconds=10)
+    mock_session.settings.expire_after = utcnow() - timedelta(seconds=10)
     mock_session.settings.allowable_codes = (200,)
     mock_session.get(MOCKED_URL_200_404)
 
@@ -709,7 +709,7 @@ def test_304_not_modified(
 ):
     url = f'{MOCKED_URL}/endpoint_2'
     if cache_expired:
-        mock_session.settings.expire_after = datetime.now(UTC) - timedelta(1)
+        mock_session.settings.expire_after = utcnow() - timedelta(1)
     if cache_hit:
         mock_session.mock_adapter.register_uri('GET', url, status_code=200)
         mock_session.get(url)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -2,7 +2,7 @@
 import json
 import pickle
 from collections import UserDict, defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from logging import getLogger
 from pathlib import Path
 from pickle import PickleError
@@ -91,7 +91,7 @@ def test_pickle__disabled():
 
 def test_response_defaults(mock_session):
     """Both cached and new responses should always have the following attributes"""
-    mock_session.settings.expire_after = datetime.utcnow() + timedelta(days=1)
+    mock_session.settings.expire_after = datetime.now(UTC) + timedelta(days=1)
     response_1 = mock_session.get(MOCKED_URL)
     response_2 = mock_session.get(MOCKED_URL)
     response_3 = mock_session.get(MOCKED_URL)
@@ -472,7 +472,7 @@ def test_stale_if_error__max_stale(mock_session):
     status code AND it is expired by less than the specified time
     """
     mock_session.settings.stale_if_error = timedelta(seconds=15)
-    mock_session.settings.expire_after = datetime.utcnow() - timedelta(seconds=10)
+    mock_session.settings.expire_after = datetime.now(UTC) - timedelta(seconds=10)
     mock_session.settings.allowable_codes = (200,)
     mock_session.get(MOCKED_URL_200_404)
 
@@ -709,7 +709,7 @@ def test_304_not_modified(
 ):
     url = f'{MOCKED_URL}/endpoint_2'
     if cache_expired:
-        mock_session.settings.expire_after = datetime.utcnow() - timedelta(1)
+        mock_session.settings.expire_after = datetime.now(UTC) - timedelta(1)
     if cache_hit:
         mock_session.mock_adapter.register_uri('GET', url, status_code=200)
         mock_session.get(url)


### PR DESCRIPTION
This makes the `now`s timezone-aware, as demanded by Python 3.12+.

Towards fixing #845.
