### PR TITLE
Allow disabling vacuum for SQLiteCache.delete(), and skip by default if only deleting one key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: snok/install-poetry@v1.3
         with:
+          version: 1.5.1  # For python 3.7 compatibility
           virtualenvs-in-project: true
 
       # Start integration test databases

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
           python-version: ${{ env.LATEST_PY_VERSION }}
       - uses: snok/install-poetry@v1.3
         with:
+          version: 1.5.1  # For python 3.7 compatibility
           virtualenvs-in-project: true
 
       # Start integration test databases
@@ -91,6 +92,7 @@ jobs:
           python-version: ${{ env.LATEST_PY_VERSION }}
       - uses: snok/install-poetry@v1.3
         with:
+          version: 1.5.1  # For python 3.7 compatibility
           virtualenvs-in-project: true
 
       # Cache packages per python version, and reuse until lockfile changes
@@ -167,6 +169,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: snok/install-poetry@v1.3
         with:
+          version: 1.5.1  # For python 3.7 compatibility
           virtualenvs-in-project: true
 
       # Cache packages per python version, and reuse until lockfile changes
@@ -202,6 +205,7 @@ jobs:
           python-version: ${{ env.LATEST_PY_VERSION }}
       - uses: snok/install-poetry@v1.3
         with:
+          version: 1.5.1  # For python 3.7 compatibility
           virtualenvs-in-project: true
 
       - name: Set pre-release version

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,9 @@
 # History
 
 ## 1.2.0 (TBD)
-* ⚠️ Remove `CachedSession` and `BaseCache` methods [deprecated in 1.0](#deprecations-1-0)
+* ⚠️ Remove methods [deprecated in 1.0](#deprecations-1-0) from `CachedSession` and `BaseCache`
+* Optimize `SQLiteCache.delete()` when deleting a single key
+* Add `vacuum` parameter to `SQLiteCache.delete()` to optionally skip vacuuming after deletion (enabled by default to free up disk space)
 
 ## 1.1.0 (2023-06-30)
 

--- a/requests_cache/backends/sqlite.py
+++ b/requests_cache/backends/sqlite.py
@@ -93,6 +93,14 @@ class SQLiteCache(BaseCache):
         vacuum: bool = True,
         **kwargs,
     ):
+        """Remove responses from the cache according one or more conditions.
+
+        Args:
+            keys: Remove responses with these cache keys
+            expired: Remove all expired responses
+            vacuum: Vacuum the database after deleting responses to free up disk space
+            kwargs: Additional keyword arguments for :py:meth:`BaseCache.delete`
+        """
         # If deleting a single key, skip bulk delete + vacuum and ignore any KeyErrors
         if len(keys) == 1:
             try:

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -382,6 +382,25 @@ class TestSQLiteCache(BaseCacheTest):
         assert session.cache.count() == 2
         assert session.cache.count(expired=False) == 1
 
+    def test_delete__single_key(self):
+        """Vacuum should not be used after delete if there is only a single key"""
+        session = self.init_session()
+        session.cache.responses['key_1'] = 'value_1'
+
+        with patch.object(SQLiteDict, 'vacuum') as mock_vacuum:
+            session.cache.delete('key_1')
+            mock_vacuum.assert_not_called()
+
+    def test_delete__skip_vacuum(self):
+        """Vacuum should not be used after delete if disabled"""
+        session = self.init_session()
+        session.cache.responses['key_1'] = 'value_1'
+        session.cache.responses['key_2'] = 'value_2'
+
+        with patch.object(SQLiteDict, 'vacuum') as mock_vacuum:
+            session.cache.delete('key_1', 'key_2', vacuum=False)
+            mock_vacuum.assert_not_called()
+
     @patch.object(SQLiteDict, 'sorted')
     def test_filter__expired(self, mock_sorted):
         """Filtering by expired should use a more efficient SQL query"""


### PR DESCRIPTION
Updates #852