### PR TITLE
Add support for HTTP method override headers

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 
 ## 1.2.0 (TBD)
 
+🕗 **Expiration & headers:**
+* Add support for `X-HTTP-Method-Override` and other headers that can override request method
+
 ⚙️ **Session methods:**
 * Add `CachedSession.wrap()` classmethod to add caching to an existing `requests.Session` object
 

--- a/docs/user_guide/filtering.md
+++ b/docs/user_guide/filtering.md
@@ -20,7 +20,15 @@ To cache additional HTTP methods, specify them with `allowable_methods`:
 
 For example, some APIs use the `POST` method to request data via a JSON-formatted request body, for
 requests that may exceed the max size of a `GET` request. You may also want to cache `POST` requests
-to ensure you don't send the exact same data multiple times.
+if you have a case where you could potentially send the exact same data multiple times.
+
+Method override headers will also be respected. For example, if a server supports the `X-HTTP-Method-Override` header, you may want to cache POST requests that only fetch data
+(overridden as GET), but not other POST requests that may create/modify data:
+```python
+>>> session = CachedSession(allowable_methods=('GET'))
+>>> session.post('https://httpbin.org/post', headers={'X-HTTP-Method-Override': 'GET'})
+```
+:::
 
 ## Filter by Status Codes
 To cache additional status codes, specify them with `allowable_codes`

--- a/requests_cache/cache_keys.py
+++ b/requests_cache/cache_keys.py
@@ -25,7 +25,7 @@ from typing import (
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from requests import Request, Session
-from requests.models import CaseInsensitiveDict
+from requests.structures import CaseInsensitiveDict
 from url_normalize import url_normalize
 
 from ._utils import decode, encode, patch_form_boundary

--- a/requests_cache/policy/directives.py
+++ b/requests_cache/policy/directives.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from typing import Optional
 
 from attr import define, field
-from requests.models import CaseInsensitiveDict
+from requests.structures import CaseInsensitiveDict
 
 from .._utils import decode, get_valid_kwargs, try_int
 from ..models import RichMixin


### PR DESCRIPTION
Closes #830

Adds support for the following nonstandard request headers (case-insensitive):
* `X-HTTP-Method-Override`
* `X-HTTP-Method`
* `X-Method-Override`

If the method specified by one of these headers is in `allowable_methods`, it will pass the check for both cache read and write.