### PR TITLE
Fix for compatibility with cattrs 23.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,9 +13,11 @@
 * Optimize `SQLiteCache.delete()` when deleting a single key
 
 🧩 **Compatibility:**
+* Add support for RFC 7159 JSON body with `decode_content=True` (root element with any type)
 * Use timezone-aware UTC datetimes for all internal expiration values
 * Add support for python 3.12
-  * Note: There is a known bug with concurrent usage of the SQLite backend on python 3.12.
+  * Note: There is a known bug with multiprocess/multithreaded usage of the SQLite backend on python 3.12.
+* Add support for cattrs 23.2
 
 🪲 **Bugfixes:**
 * Handle a corner case with streaming requests, conditional requests, and redirects
@@ -25,6 +27,9 @@
 ⚠️ **Deprecations & removals:**
 * Drop support for python 3.7
 * Remove methods [deprecated in 1.0](#deprecations-1-0) from `CachedSession` and `BaseCache`
+
+## 1.1.1 (2023-11-18)
+* Backport fix from 1.2: Add compatibility with cattrs 23.2
 
 ## 1.1.0 (2023-06-30)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,13 +13,13 @@ files = [
 
 [[package]]
 name = "argcomplete"
-version = "3.1.4"
+version = "3.1.6"
 description = "Bash tab completion for argparse"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "argcomplete-3.1.4-py3-none-any.whl", hash = "sha256:fbe56f8cda08aa9a04b307d8482ea703e96a6a801611acb4be9bf3942017989f"},
-    {file = "argcomplete-3.1.4.tar.gz", hash = "sha256:72558ba729e4c468572609817226fb0a6e7e9a0a7d477b882be168c0b4a62b94"},
+    {file = "argcomplete-3.1.6-py3-none-any.whl", hash = "sha256:71f4683bc9e6b0be85f2b2c1224c47680f210903e23512cfebfe5a41edfd883a"},
+    {file = "argcomplete-3.1.6.tar.gz", hash = "sha256:3b1f07d133332547a53c79437527c00be48cca3807b1d4ca5cab1b26313386a6"},
 ]
 
 [package.extras]
@@ -92,17 +92,17 @@ lxml = ["lxml"]
 
 [[package]]
 name = "boto3"
-version = "1.28.78"
+version = "1.29.3"
 description = "The AWS SDK for Python"
 optional = true
 python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.28.78-py3-none-any.whl", hash = "sha256:ff8df4bb5aeb69acc64959a74b31042bfc52d64ca77dbe845a72c8062c48d179"},
-    {file = "boto3-1.28.78.tar.gz", hash = "sha256:aa970b1571321846543a6e615848352fe7621f1cb96b4454e919421924af95f7"},
+    {file = "boto3-1.29.3-py3-none-any.whl", hash = "sha256:85123ba6ccef12f8230bcd85bf730d3c4218e08e3cc4baaa0b3eae094703e77d"},
+    {file = "boto3-1.29.3.tar.gz", hash = "sha256:d038b19cbe29d488133351ee6eb36ee11a0934df8bcbc0892bbeb2c544a327a4"},
 ]
 
 [package.dependencies]
-botocore = ">=1.31.78,<1.32.0"
+botocore = ">=1.32.3,<1.33.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.7.0,<0.8.0"
 
@@ -111,13 +111,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.31.78"
+version = "1.32.3"
 description = "Low-level, data-driven core of boto 3."
 optional = true
 python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.31.78-py3-none-any.whl", hash = "sha256:a9ca8deeb3f47a10a25637859fee8d81cac2db37ace819d24471279e44879547"},
-    {file = "botocore-1.31.78.tar.gz", hash = "sha256:320c70bc412157813c2cf60217a592b4b345f8e97e4bf3b1ce49b6be69ed8965"},
+    {file = "botocore-1.32.3-py3-none-any.whl", hash = "sha256:115adb7edf61ad7083fd582ac749b761fa707758bbca94d42e4e6e92940b5d38"},
+    {file = "botocore-1.32.3.tar.gz", hash = "sha256:be622915db1dbf1d6d5ed907633471f9ed8f5399dd3cf333f9dc2b955cd3e80d"},
 ]
 
 [package.dependencies]
@@ -129,7 +129,7 @@ urllib3 = [
 ]
 
 [package.extras]
-crt = ["awscrt (==0.16.26)"]
+crt = ["awscrt (==0.19.12)"]
 
 [[package]]
 name = "bson"
@@ -147,38 +147,38 @@ six = ">=1.9.0"
 
 [[package]]
 name = "cattrs"
-version = "23.1.2"
+version = "23.2.1"
 description = "Composable complex class support for attrs and dataclasses."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "cattrs-23.1.2-py3-none-any.whl", hash = "sha256:b2bb14311ac17bed0d58785e5a60f022e5431aca3932e3fc5cc8ed8639de50a4"},
-    {file = "cattrs-23.1.2.tar.gz", hash = "sha256:db1c821b8c537382b2c7c66678c3790091ca0275ac486c76f3c8f3920e83c657"},
+    {file = "cattrs-23.2.1-py3-none-any.whl", hash = "sha256:c505344019b1a2708c775ffb1b8d092654d22a570799bb7b925c9effefc22703"},
+    {file = "cattrs-23.2.1.tar.gz", hash = "sha256:c9685821a75dc8588b90e847f47bcb6fba7bce8f280d5dc4edd3290e827854ec"},
 ]
 
 [package.dependencies]
-attrs = ">=20"
-exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
-typing_extensions = {version = ">=4.1.0", markers = "python_version < \"3.11\""}
+attrs = ">=23.1.0"
+exceptiongroup = {version = ">=1.1.1", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=4.1.0,<4.6.3 || >4.6.3", markers = "python_version < \"3.11\""}
 
 [package.extras]
-bson = ["pymongo (>=4.2.0,<5.0.0)"]
-cbor2 = ["cbor2 (>=5.4.6,<6.0.0)"]
-msgpack = ["msgpack (>=1.0.2,<2.0.0)"]
-orjson = ["orjson (>=3.5.2,<4.0.0)"]
-pyyaml = ["PyYAML (>=6.0,<7.0)"]
-tomlkit = ["tomlkit (>=0.11.4,<0.12.0)"]
-ujson = ["ujson (>=5.4.0,<6.0.0)"]
+bson = ["pymongo (>=4.4.0)"]
+cbor2 = ["cbor2 (>=5.4.6)"]
+msgpack = ["msgpack (>=1.0.5)"]
+orjson = ["orjson (>=3.9.2)"]
+pyyaml = ["pyyaml (>=6.0)"]
+tomlkit = ["tomlkit (>=0.11.8)"]
+ujson = ["ujson (>=5.7.0)"]
 
 [[package]]
 name = "certifi"
-version = "2023.7.22"
+version = "2023.11.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
-    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
+    {file = "certifi-2023.11.17-py3-none-any.whl", hash = "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"},
+    {file = "certifi-2023.11.17.tar.gz", hash = "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"},
 ]
 
 [[package]]
@@ -489,13 +489,13 @@ sphinx-basic-ng = "*"
 
 [[package]]
 name = "identify"
-version = "2.5.31"
+version = "2.5.32"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "identify-2.5.31-py2.py3-none-any.whl", hash = "sha256:90199cb9e7bd3c5407a9b7e81b4abec4bb9d249991c79439ec8af740afc6293d"},
-    {file = "identify-2.5.31.tar.gz", hash = "sha256:7736b3c7a28233637e3c36550646fc6389bedd74ae84cb788200cc8e2dd60b75"},
+    {file = "identify-2.5.32-py2.py3-none-any.whl", hash = "sha256:0b7656ef6cba81664b783352c73f8c24b39cf82f926f78f4550eda928e5e0545"},
+    {file = "identify-2.5.32.tar.gz", hash = "sha256:5d9979348ec1a21c768ae07e0a652924538e8bce67313a73cb0f681cf08ba407"},
 ]
 
 [package.extras]
@@ -829,13 +829,13 @@ files = [
 
 [[package]]
 name = "pbr"
-version = "5.11.1"
+version = "6.0.0"
 description = "Python Build Reasonableness"
 optional = true
 python-versions = ">=2.6"
 files = [
-    {file = "pbr-5.11.1-py2.py3-none-any.whl", hash = "sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b"},
-    {file = "pbr-5.11.1.tar.gz", hash = "sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3"},
+    {file = "pbr-6.0.0-py2.py3-none-any.whl", hash = "sha256:4a7317d5e3b17a3dccb6a8cfe67dab65b20551404c52c8ed41279fa4f0cb4cda"},
+    {file = "pbr-6.0.0.tar.gz", hash = "sha256:d1377122a5a00e2f940ee482999518efe16d745d423a670c27773dfbc3c9a7d9"},
 ]
 
 [[package]]
@@ -927,17 +927,18 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pygments"
-version = "2.16.1"
+version = "2.17.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Pygments-2.16.1-py3-none-any.whl", hash = "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692"},
-    {file = "Pygments-2.16.1.tar.gz", hash = "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"},
+    {file = "pygments-2.17.0-py3-none-any.whl", hash = "sha256:cd0c46944b2551af02ecc15961050182ea120d3895000e2676160820f3421527"},
+    {file = "pygments-2.17.0.tar.gz", hash = "sha256:edaa0fa2453d055d0ac94449d1f73ec7bc52c5e318204da1377c1392978c4a8d"},
 ]
 
 [package.extras]
 plugins = ["importlib-metadata"]
+windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pymongo"
@@ -1113,13 +1114,13 @@ pytest = ">=5.3"
 
 [[package]]
 name = "pytest-xdist"
-version = "3.3.1"
+version = "3.4.0"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-xdist-3.3.1.tar.gz", hash = "sha256:d5ee0520eb1b7bcca50a60a518ab7a7707992812c578198f8b44fdfac78e8c93"},
-    {file = "pytest_xdist-3.3.1-py3-none-any.whl", hash = "sha256:ff9daa7793569e6a68544850fd3927cd257cc03a7ef76c95e86915355e82b5f2"},
+    {file = "pytest-xdist-3.4.0.tar.gz", hash = "sha256:3a94a931dd9e268e0b871a877d09fe2efb6175c2c23d60d56a6001359002b832"},
+    {file = "pytest_xdist-3.4.0-py3-none-any.whl", hash = "sha256:e513118bf787677a427e025606f55e95937565e06dfaac8d87f55301e57ae607"},
 ]
 
 [package.dependencies]
@@ -1284,13 +1285,13 @@ tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asy
 
 [[package]]
 name = "rich"
-version = "13.6.0"
+version = "13.7.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "rich-13.6.0-py3-none-any.whl", hash = "sha256:2b38e2fe9ca72c9a00170a1a2d20c63c790d0e10ef1fe35eba76e1e7b1d7d245"},
-    {file = "rich-13.6.0.tar.gz", hash = "sha256:5c14d22737e6d5084ef4771b62d5d4363165b403455a30a1c8ca39dc7b644bef"},
+    {file = "rich-13.7.0-py3-none-any.whl", hash = "sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235"},
+    {file = "rich-13.7.0.tar.gz", hash = "sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa"},
 ]
 
 [package.dependencies]
@@ -1757,13 +1758,13 @@ files = [
 
 [[package]]
 name = "tomlkit"
-version = "0.12.2"
+version = "0.12.3"
 description = "Style preserving TOML library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tomlkit-0.12.2-py3-none-any.whl", hash = "sha256:eeea7ac7563faeab0a1ed8fe12c2e5a51c61f933f2502f7e9db0241a65163ad0"},
-    {file = "tomlkit-0.12.2.tar.gz", hash = "sha256:df32fab589a81f0d7dc525a4267b6d7a64ee99619cbd1eeb0fae32c1dd426977"},
+    {file = "tomlkit-0.12.3-py3-none-any.whl", hash = "sha256:b0a645a9156dc7cb5d3a1f0d4bab66db287fcb8e0430bdd4664a095ea16414ba"},
+    {file = "tomlkit-0.12.3.tar.gz", hash = "sha256:75baf5012d06501f07bee5bf8e801b9f343e7aac5a92581f20f80ce632e6b5a4"},
 ]
 
 [[package]]

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -17,8 +17,12 @@ from . import CachedHTTPResponse, CachedRequest, RichMixin
 if TYPE_CHECKING:
     from ..policy.actions import CacheActions
 
-DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S %Z'  # Format used for __str__ only
-DecodedContent = Union[Dict, List, str, None]
+# Format used for __str__ only
+DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
+
+# Support RFC 7159: JSON body root element can be an object, array, or any of its primitive types
+DecodedContent = Union[Dict, List, str, bool, int, float, None]
+
 logger = getLogger(__name__)
 
 

--- a/requests_cache/serializers/preconf.py
+++ b/requests_cache/serializers/preconf.py
@@ -9,7 +9,7 @@ from functools import partial
 from importlib import import_module
 
 from .._utils import get_placeholder_class
-from .cattrs import CattrStage, make_decimal_timedelta_converter
+from .cattrs import CattrStage, _convert_floats, make_decimal_timedelta_converter
 from .pipeline import SerializerPipeline, Stage
 
 
@@ -142,8 +142,9 @@ except ImportError as e:
 dynamodb_preconf_stage = CattrStage(
     factory=make_decimal_timedelta_converter, convert_timedelta=False
 )  #: Pre-serialization steps for DynamoDB
+convert_float_stage = Stage(dumps=_convert_floats, loads=lambda x: x)
 dynamodb_document_serializer = SerializerPipeline(
-    [dynamodb_preconf_stage],
+    [dynamodb_preconf_stage, convert_float_stage],
     name='dynamodb_document',
     is_binary=False,
 )  #: DynamoDB-compatible document serializer

--- a/tests/benchmark_serializers.py
+++ b/tests/benchmark_serializers.py
@@ -28,7 +28,7 @@ from os.path import abspath, dirname, join
 from time import perf_counter as time
 
 import ujson
-from cattr.preconf.json import make_converter
+from cattrs.preconf.json import make_converter
 
 from requests_cache.backends.sqlite import SQLiteCache
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,7 +206,13 @@ def get_mock_adapter() -> Adapter:
         ANY_METHOD,
         MOCKED_URL_JSON,
         headers={'Content-Type': 'application/json'},
-        json={'message': 'mock json response'},
+        json={
+            'message': 'mock json response',
+            'int': 47,
+            'float': 47.1,
+            'bool': True,
+            'null': None,
+        },
         status_code=200,
     )
     adapter.register_uri(

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -284,6 +284,26 @@ class BaseCacheTest:
         r2 = session.get(url)
         assert r1.json() == r2.json()
 
+    @pytest.mark.parametrize('decode_content', [True, False])
+    @pytest.mark.parametrize('body', ['string', 47, 47.1, True])
+    def test_decode_json_with_primitive_root(self, decode_content, body):
+        """Test that JSON responses (with primitive type root) are correctly returned from the
+        cache, regardless of `decode_content` setting"""
+        session = self.init_session(decode_content=decode_content)
+        session = mount_mock_adapter(session)
+        url = 'http+mock://requests-cache.com/json_alt'
+        session.mock_adapter.register_uri(
+            'GET',
+            url,
+            headers={'Content-Type': 'application/json'},
+            json=body,
+            status_code=200,
+        )
+
+        r1 = session.get(url)
+        r2 = session.get(url)
+        assert r1.json() == r2.json()
+
     def test_multipart_upload(self):
         session = self.init_session()
         session.post(httpbin('post'), files={'file1': BytesIO(b'10' * 1024)})

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from requests_cache.backends import DynamoDbCache, DynamoDbDict
-from tests.conftest import CACHE_NAME, MOCKED_URL_JSON_LIST, fail_if_no_connection
+from tests.conftest import CACHE_NAME, fail_if_no_connection
 from tests.integration.base_cache_test import BaseCacheTest
 from tests.integration.base_storage_test import BaseStorageTest
 
@@ -89,17 +89,6 @@ class TestDynamoDbDict(BaseStorageTest):
             assert ttl_value is None
 
 
-# TODO: Fix DynamoDB serialization of JSON body with floats -> Decimals
 class TestDynamoDbCache(BaseCacheTest):
     backend_class = DynamoDbCache
     init_kwargs = AWS_OPTIONS
-
-    @pytest.mark.parametrize('decode_content', [True, False])
-    @pytest.mark.parametrize('url', [MOCKED_URL_JSON_LIST])
-    def test_decode_json_response(self, decode_content, url):
-        super().test_decode_json_response(decode_content, url)
-
-    @pytest.mark.parametrize('decode_content', [True, False])
-    @pytest.mark.parametrize('body', ['string', 47, True])
-    def test_decode_json_with_primitive_root(self, decode_content, body):
-        super().test_decode_json_with_primitive_root(decode_content, body)

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from requests_cache.backends import DynamoDbCache, DynamoDbDict
-from tests.conftest import CACHE_NAME, fail_if_no_connection
+from tests.conftest import CACHE_NAME, MOCKED_URL_JSON_LIST, fail_if_no_connection
 from tests.integration.base_cache_test import BaseCacheTest
 from tests.integration.base_storage_test import BaseStorageTest
 
@@ -89,6 +89,17 @@ class TestDynamoDbDict(BaseStorageTest):
             assert ttl_value is None
 
 
+# TODO: Fix DynamoDB serialization of JSON body with floats -> Decimals
 class TestDynamoDbCache(BaseCacheTest):
     backend_class = DynamoDbCache
     init_kwargs = AWS_OPTIONS
+
+    @pytest.mark.parametrize('decode_content', [True, False])
+    @pytest.mark.parametrize('url', [MOCKED_URL_JSON_LIST])
+    def test_decode_json_response(self, decode_content, url):
+        super().test_decode_json_response(decode_content, url)
+
+    @pytest.mark.parametrize('decode_content', [True, False])
+    @pytest.mark.parametrize('body', ['string', 47, True])
+    def test_decode_json_with_primitive_root(self, decode_content, body):
+        super().test_decode_json_with_primitive_root(decode_content, body)

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-from cattr import BaseConverter, GenConverter
+from cattrs import BaseConverter, GenConverter
 
 from requests_cache import (
     CachedResponse,


### PR DESCRIPTION
#907, fixes #868

Note: after refactoring handling of `decode_content`, an issue came up with the DynamoDB backend with serializing a JSON body with float values. These need to be converted to Decimals, but I couldn't figure out a way to integrate this into the existing converter. I added a (hopefully) temporary workaround for this.