### PR TITLE
Replace unsupported characters in patched form boundary

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,7 @@
 * Handle a corner case with streaming requests, conditional requests, and redirects
 * When redacting ignored parameters from a cached response, keep the rest of the original URL and headers without normalizing
 * Add `CachedHTTPResponse._request_url` property for compatibility with urllib3
+* Fix form boundary used for cached multipart requests to compy with RFC 2046
 
 ⚠️ **Deprecations & removals:**
 * Drop support for python 3.7

--- a/requests_cache/_utils.py
+++ b/requests_cache/_utils.py
@@ -6,6 +6,8 @@ from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tupl
 
 from urllib3 import filepost
 
+FORM_BOUNDARY = '==requests-cache-form-boundary=='
+
 KwargDict = Dict[str, Any]
 logger = getLogger('requests_cache')
 
@@ -76,7 +78,7 @@ def patch_form_boundary():
     monkey-patches it instead.
     """
     original_boundary = filepost.choose_boundary
-    filepost.choose_boundary = lambda: '##requests-cache-form-boundary##'
+    filepost.choose_boundary = lambda: FORM_BOUNDARY
     yield
     filepost.choose_boundary = original_boundary
 


### PR DESCRIPTION
TIL: According to RFC 2046, a form boundary in a multipart request can only include "characters known to be very robust through mail gateways" (as of 1996?):
```c
boundary := 0*69<bchars> bcharsnospace

bchars := bcharsnospace / " "

bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" /
                 "+" / "_" / "," / "-" / "." /
                 "/" / ":" / "=" / "?"
```

Fixes #917
