### PR TITLE
Consistently use 'attrs' namespace instead of 'attr'

### DIFF
--- a/requests_cache/models/base.py
+++ b/requests_cache/models/base.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List
 
-from attr import Factory
+from attrs import Factory
 
 
 class RichMixin:

--- a/requests_cache/models/raw_response.py
+++ b/requests_cache/models/raw_response.py
@@ -2,7 +2,7 @@ from io import BytesIO
 from logging import getLogger
 from typing import TYPE_CHECKING, Optional
 
-from attr import define, field, fields_dict
+from attrs import define, field, fields_dict
 from requests import Response
 from urllib3.response import (  # type: ignore  # import location false positive
     HTTPHeaderDict,

--- a/requests_cache/models/request.py
+++ b/requests_cache/models/request.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 from urllib.parse import urlsplit
 
-from attr import asdict, define, field, fields_dict
+from attrs import asdict, define, field, fields_dict
 from requests import PreparedRequest
 from requests.cookies import RequestsCookieJar
 from requests.structures import CaseInsensitiveDict

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -6,7 +6,7 @@ from time import time
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import attr
-from attr import define, field
+from attrs import define, field
 from requests import PreparedRequest, Response
 from requests.cookies import RequestsCookieJar
 from requests.structures import CaseInsensitiveDict

--- a/requests_cache/policy/actions.py
+++ b/requests_cache/policy/actions.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from logging import DEBUG, getLogger
 from typing import TYPE_CHECKING, Dict, List, MutableMapping, Optional, Union
 
-from attr import define, field
+from attrs import define, field
 from requests import PreparedRequest, Response
 from requests.structures import CaseInsensitiveDict
 

--- a/requests_cache/policy/directives.py
+++ b/requests_cache/policy/directives.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Optional
 
-from attr import define, field
+from attrs import define, field
 from requests.structures import CaseInsensitiveDict
 
 from .._utils import decode, get_valid_kwargs, try_int

--- a/requests_cache/policy/settings.py
+++ b/requests_cache/policy/settings.py
@@ -1,6 +1,6 @@
 from typing import Dict, Iterable, Union
 
-from attr import define, field
+from attrs import define, field
 
 from .._utils import get_valid_kwargs
 from ..models import RichMixin

--- a/tests/unit/models/test_base.py
+++ b/tests/unit/models/test_base.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from attr import define, field
+from attrs import define, field
 
 from requests_cache.models import RichMixin
 


### PR DESCRIPTION
Related to #918 