### PR TITLE
Store `verify=True` and `verify=cert path` under same cache key

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,7 +23,8 @@
 * Handle a corner case with streaming requests, conditional requests, and redirects
 * When redacting ignored parameters from a cached response, keep the rest of the original URL and headers without normalizing
 * Add `CachedHTTPResponse._request_url` property for compatibility with urllib3
-* Fix form boundary used for cached multipart requests to compy with RFC 2046
+* Fix form boundary used for cached multipart requests to comply with RFC 2046
+* If an explicit CA bundle path is passed via `verify` param, cache the response under the same key as `verify=True`
 
 ⚠️ **Deprecations & removals:**
 * Drop support for python 3.7

--- a/requests_cache/cache_keys.py
+++ b/requests_cache/cache_keys.py
@@ -72,7 +72,7 @@ def create_key(
         request.method or '',
         request.url,
         request.body or '',
-        request_kwargs.get('verify', True),
+        bool(request_kwargs.get('verify', True)),
         *get_matched_headers(request.headers, match_headers),
         str(serializer),
     ]

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -204,11 +204,6 @@ def test_params_positional_arg(mock_session):
     assert 'param_1=1' in response.url
 
 
-def test_https(mock_session):
-    assert mock_session.get(MOCKED_URL_HTTPS, verify=True).from_cache is False
-    assert mock_session.get(MOCKED_URL_HTTPS, verify=True).from_cache is True
-
-
 def test_json(mock_session):
     assert mock_session.get(MOCKED_URL_JSON).from_cache is False
     response = mock_session.get(MOCKED_URL_JSON)
@@ -216,11 +211,21 @@ def test_json(mock_session):
     assert response.json()['message'] == 'mock json response'
 
 
+def test_https(mock_session):
+    assert mock_session.get(MOCKED_URL_HTTPS, verify=True).from_cache is False
+    assert mock_session.get(MOCKED_URL_HTTPS, verify=True).from_cache is True
+
+
 def test_verify(mock_session):
     mock_session.get(MOCKED_URL)
-    assert mock_session.get(MOCKED_URL).from_cache is True
-    assert mock_session.get(MOCKED_URL, verify=False).from_cache is False
-    assert mock_session.get(MOCKED_URL, verify='/path/to/cert').from_cache is False
+    r1 = mock_session.get(MOCKED_URL, verify=True)
+    r2 = mock_session.get(MOCKED_URL, verify='/path/to/cert')
+    r3 = mock_session.get(MOCKED_URL, verify=False)
+
+    assert r1.from_cache is True
+    assert r2.from_cache is True
+    assert r3.from_cache is False
+    assert r1.cache_key == r2.cache_key
 
 
 def test_response_history(mock_session):


### PR DESCRIPTION
Closes #940, #939