### PR TITLE
Remove "bson" explicit dependency because it is shipped with "pymongo"

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,6 +26,7 @@
 * Fix form boundary used for cached multipart requests to comply with RFC 2046
 * If an explicit CA bundle path is passed via `verify` param, cache the response under the same key as `verify=True`
 * Handle JSON Content-Type charsets and MIME type variations (such as `application/vnd.api+json`) during request normalization and serialization
+* Removed 'bson' from the explicit dependencies because PyMongo comes with its own bson package. Read the warning: https://pymongo.readthedocs.io/en/stable/installation.html#installing-upgrading
 
 ⚠️ **Deprecations & removals:**
 * Drop support for python 3.7

--- a/poetry.lock
+++ b/poetry.lock
@@ -135,20 +135,6 @@ urllib3 = [
 crt = ["awscrt (==0.19.19)"]
 
 [[package]]
-name = "bson"
-version = "0.5.10"
-description = "BSON codec for Python"
-optional = true
-python-versions = "*"
-files = [
-    {file = "bson-0.5.10.tar.gz", hash = "sha256:d6511b2ab051139a9123c184de1a04227262173ad593429d21e443d6462d6590"},
-]
-
-[package.dependencies]
-python-dateutil = ">=2.4.0"
-six = ">=1.9.0"
-
-[[package]]
 name = "cattrs"
 version = "23.2.3"
 description = "Composable complex class support for attrs and dataclasses."
@@ -1198,7 +1184,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1997,7 +1982,6 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [extras]
 all = ["boto3", "botocore", "itsdangerous", "pymongo", "pyyaml", "redis", "ujson"]
-bson = ["bson"]
 docs = ["furo", "linkify-it-py", "myst-parser", "sphinx", "sphinx-autodoc-typehints", "sphinx-automodapi", "sphinx-copybutton", "sphinx-design", "sphinx-notfound-page", "sphinxcontrib-apidoc", "sphinxext-opengraph"]
 dynamodb = ["boto3", "botocore"]
 json = ["ujson"]
@@ -2009,4 +1993,4 @@ yaml = ["pyyaml"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "7915284f6c005ad981dbc26e04928bb8226d02337f7321777efa96a3fd272cee"
+content-hash = "2263fdcd069d0b7b95184c0705e31f4c33147ca67d62665687d01020207c1736"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ pymongo                    = {optional=true, version=">=3"}
 redis                      = {optional=true, version=">=3"}
 
 # Optional serialization dependencies
-bson                       = {optional=true, version=">=0.5"}
 itsdangerous               = {optional=true, version=">=2.0"}
 pyyaml                     = {optional=true, version=">=6.0.1"}
 ujson                      = {optional=true, version=">=5.4"}
@@ -85,7 +84,6 @@ mongodb  = ["pymongo"]
 redis    = ["redis"]
 
 # Package extras for optional seriazliation dependencies
-bson     = ["bson"]   # BSON comes with pymongo, but can also be used as a standalone codec
 json     = ["ujson"]  # Will optionally be used by JSON serializer for improved performance
 security = ["itsdangerous"]
 yaml     = ["pyyaml"]


### PR DESCRIPTION
Closes #877

### Error

Steps to reproduce:

1. Run `poetry --version` to make sure you have `1.7.1`.
2. Switch to Python 3.8 (use https://github.com/pyenv/pyenv)
3. `poetry shell`
4. Run `python --version` to make sure you use `Python 3.8.18` inside the Poetry shell.
5. `poetry install --all-extras`
6. Run `pytest tests`.

Traceback:

```py
requests_cache/serializers/preconf.py:19: in make_stage
    factory = import_module(preconf_module).make_converter
../../.pyenv/versions/3.8.18/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1014: in _gcd_import
    ???
<frozen importlib._bootstrap>:991: in _find_and_load
    ???
<frozen importlib._bootstrap>:975: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:671: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:843: in exec_module
    ???
<frozen importlib._bootstrap>:219: in _call_with_frames_removed
    ???
.venv/lib/python3.8/site-packages/cattr/preconf/bson.py:2: in <module>
    from cattrs.preconf.bson import BsonConverter, configure_converter, make_converter
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    """Preconfigured converters for bson."""
    from base64 import b85decode, b85encode
    from datetime import date, datetime
    from typing import Any, Type, TypeVar, Union
    
>   from bson import DEFAULT_CODEC_OPTIONS, CodecOptions, Int64, ObjectId, decode, encode
E   ImportError: cannot import name 'DEFAULT_CODEC_OPTIONS' from 'bson' (/home/sam/projects/requests-cache/.venv/lib/python3.8/site-packages/bson/__init__.py)

.venv/lib/python3.8/site-packages/cattrs/preconf/bson.py:6: ImportError
```

### Checklist
- [x] Added docstrings and type annotations
- [x] Added test coverage
- [x] Updated changelog to describe any user-facing features or changed behavior
