### PR TITLE
reset `_fp_bytes_read` and `length_remaining` on raw response to avoid `Incompleteread` with `urllib3` 2.x

### DIFF
--- a/requests_cache/models/raw_response.py
+++ b/requests_cache/models/raw_response.py
@@ -67,6 +67,8 @@ class CachedHTTPResponse(RichMixin, HTTPResponse):
                 body = raw.read(decode_content=False)
                 kwargs['body'] = body
                 raw._fp = BytesIO(body)
+                raw._fp_bytes_read = 0
+                raw.length_remaining = len(body)
                 _ = response.content  # This property reads, decodes, and stores response content
 
                 # After reading, reset file pointer on original raw response


### PR DESCRIPTION
The following situation triggered `IncompleteRead` error with `urllib3>=2.0`, same way as [here](https://github.com/psf/cachecontrol/issues/295): 

```
pip install omnipath requests_cache
```

```
import requests_cache
requests_cache.install_cache('foobar')
import omnipath as op
```

The import of `omnipath` issues some downloads by `requests` the following way (I tried to create a minimal reproducible example based on the [code here](https://github.com/saezlab/omnipath/blob/main/omnipath/_core/downloader/_downloader.py)):

```
from requests import Request, Session
from requests.adapters import HTTPAdapter
from urllib3.util import Retry
from io import BytesIO
from tqdm import tqdm
import requests_cache

requests_cache.install_cache('foobar')

url = 'https://omnipathdb.org/about'
session = Session()
retries = Retry(
    total = 1,
    redirect = 5,
    status_forcelist = [413,429,500,502,503,504],
    backoff_factor = 1,
)
adapter = HTTPAdapter(max_retries = retries)
session.mount('http://', adapter)
session.mount('https://', adapter)

request = Request(
    'GET',
    url,
    params = {'format': 'text'},
    headers = {'User-Agent': 'omnipathdb-user'},
)

prequest = session.prepare_request(request)
handle = BytesIO()

with session.send(prequest, stream = True, timeout = (1, 3)) as response:

    response.raise_for_status()
    total = response.headers.get('content-length', None)

    with tqdm(
        unit = 'B',
        unit_scale = True,
        miniters = 1,
        unit_divisor = 1024,
        total = total if total is None else int(total),
    ) as t:
        for chunk in response.iter_content(chunk_size = 1024):
            t.update(len(chunk))
            handle.write(chunk)

    handle.flush()
    handle.seek(0)


print(handle.read(100))
```

Interestingly, the code above itself doesn't trigger the `IncompleteRead` error, I was unable to find out why. However, resetting the `_fp_bytes_read` and `length_remaining` properties as suggested in this PR fixes the issue experienced when the `omnipath` module performs requests. I tested the solution with `urllib3` 1.26.18 and `requests` 2.29.0, and `urllib3` 2.2.0 and `requests` 2.31.0, with both the example that triggered the error and the one which didn't. All scenarios worked without error. And for me it seems logical that these values should be reset before accessing `respones.content`, which apparently calls `_fp.read` again. For these reasons I think this PR might improve the situation.