### PR TITLE
Fix typo in doc/expiration.md

### DIFF
--- a/docs/user_guide/expiration.md
+++ b/docs/user_guide/expiration.md
@@ -86,7 +86,7 @@ Examples:
 ```
 
 **Notes:**
-- `urls_expire_after` should be a dict in the format `{pattern': expire_after}`
+- `urls_expire_after` should be a dict in the format `{pattern: expire_after}`
 - `expire_after` accepts the same types as `CachedSession.settings.expire_after`
 - **Glob patterns** will match request **base URLs without the protocol**, so the pattern `site.com/resource/`
   is equivalent to `http*://site.com/resource/**`.


### PR DESCRIPTION
Stray apostrophe detected:
- https://requests-cache.readthedocs.io/en/stable/user_guide/expiration.html