### PR TITLE
Fix inconsistency due to rounding in CachedResponse.expires_unix property

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,10 @@
 # History
 
-## 1.2.1 (2024-02-xx)
+## Unreleased
 
 🪲 **Bugfixes:**
 * Fix `normalize_headers` not accepting header values in bytes
+* Fix inconsistency due to rounding in `CachedResponse.expires_unix` property
 
 ## 1.2.0 (2024-02-17)
 

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from logging import getLogger
-from time import time
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import attr
@@ -144,8 +143,9 @@ class CachedResponse(RichMixin, BaseResponse):
     @property
     def expires_unix(self) -> Optional[int]:
         """Get expiration time as a Unix timestamp"""
-        seconds = self.expires_delta
-        return round(time() + seconds) if seconds is not None else None
+        if self.expires is None:
+            return None
+        return round(self.expires.timestamp())
 
     @property
     def from_cache(self) -> bool:


### PR DESCRIPTION
Closes #975

Example to manually verify consistency:
```py
from requests_cache import CachedResponse
from datetime import datetime

r = CachedResponse(expires=datetime.now())
timestamps = {r.expires_unix for _ in range(10000000)}
assert len(set(timestamps)) == 1
```