### PR TITLE
Fixes error 400 responses from patched form boundary

### DIFF
--- a/requests_cache/_utils.py
+++ b/requests_cache/_utils.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tupl
 
 from urllib3 import filepost
 
-FORM_BOUNDARY = '==requests-cache-form-boundary=='
+FORM_BOUNDARY = '--requests-cache-form-boundary--'
 
 KwargDict = Dict[str, Any]
 logger = getLogger('requests_cache')


### PR DESCRIPTION
Requests_cache version 1.2.0 causes our server to respond with error 400 on multipart requests.

After some investigation, i tracked this down to PR #919:
With the older format i get a proper response (status 200): `FORM_BOUNDARY = '##requests-cache-form-boundary##'`
With the new format i get error 400: `FORM_BOUNDARY = '==requests-cache-form-boundary=='`

I'm not very experienced with requests, but to my understanding [RFC2046](https://www.rfc-editor.org/rfc/rfc2046#section-5.1.1) suggests "The boundary delimiter line is then defined as a line consisting entirely of two hyphen characters ("-", decimal value 45) [...]"

So, i tested replacing the "==" with hyphens "--" in the below formats:

1. `FORM_BOUNDARY = '--requests-cache-form-boundary--'`
2. `FORM_BOUNDARY = '--requests-cache-form-boundary'`

Both formats above seem to be accepted with no problems. 

Unless i am missing something, I would propose to keep the 1st format, which seems more in line with the past forms.