### PR TITLE
Fix usage example/test with `responses` library to be compatible with `requests` 2.32

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 * Fix `normalize_headers` not accepting header values in bytes
 * Fix inconsistency due to rounding in `CachedResponse.expires_unix` property
 * Fix form boundary used for cached multipart requests to _fully_ comply with RFC 2046
+* Fix usage example with `responses` library to be compatible with `requests` 2.32
 
 ## 1.2.0 (2024-02-17)
 

--- a/tests/compat/test_responses_load_cache.py
+++ b/tests/compat/test_responses_load_cache.py
@@ -44,7 +44,9 @@ def get_responses():
 
 # responses patches HTTPAdapter.send(), so we need to patch one level lower to verify request mocking
 @patch.object(
-    requests.adapters.HTTPAdapter, 'get_connection', side_effect=ValueError('Real request made!')
+    requests.adapters.HTTPAdapter,
+    'get_connection_with_tls_context',
+    side_effect=ValueError('Real request made!'),
 )
 def test_mock_session(mock_http_adapter):
     """Test that the mock_session fixture is working as expected"""


### PR DESCRIPTION
Fixes #990

In `requests` 2.32, `HTTPAdapter.get_connection()` can no longer be used to detect a real request made (with the default `verify=True`). The fix is to use `get_connection_with_tls_context()` instead.

That being said, a potential improvement for this example/test would be to use a lower-level/client-agnostic way to detect a real request made.