### PR TITLE
Fix loading cached JSON content with `decode_content=True` when the root element is empty

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 * Fix `normalize_headers` not accepting header values in bytes
 * Fix inconsistency due to rounding in `CachedResponse.expires_unix` property
 * Fix form boundary used for cached multipart requests to _fully_ comply with RFC 2046
+* Fix loading cached JSON content with `decode_content=True` when the root element is an empty list or object
 * Fix usage example with `responses` library to be compatible with `requests` 2.32
 
 ## 1.2.0 (2024-02-17)

--- a/requests_cache/serializers/cattrs.py
+++ b/requests_cache/serializers/cattrs.py
@@ -13,21 +13,22 @@ serialization formats.
 """
 
 from __future__ import annotations
+
+from collections.abc import MutableMapping
 from datetime import datetime, timedelta
 from decimal import Decimal
+from functools import singledispatchmethod
 from json import JSONDecodeError
 from typing import Callable, Dict, ForwardRef, List, Optional, Union
-from functools import singledispatchmethod
-from collections.abc import MutableMapping
 
 from cattrs import Converter
 from requests.cookies import RequestsCookieJar, cookiejar_from_dict
 from requests.exceptions import RequestException
 from requests.structures import CaseInsensitiveDict
 
+from .._utils import is_json_content_type
 from ..models import CachedResponse, DecodedContent
 from .pipeline import Stage
-from .._utils import is_json_content_type
 
 try:
     import ujson as json
@@ -186,7 +187,7 @@ def _encode_content(response: CachedResponse) -> CachedResponse:
     This has no effect for a binary response body.
     """
     # The response may have previously been saved with `decode_content=False`
-    if not response._decoded_content:
+    if response._decoded_content is None:
         return response
 
     # Encode body as JSON

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -246,7 +246,10 @@ class BaseCacheTest:
         session.get(url, params=first_response_headers)
 
         # Add different Response Header to mocked return value of the session.send() function.
-        updated_response_headers = {**first_response_headers, 'Cache-Control': 'max-age=60'}
+        updated_response_headers = {
+            **first_response_headers,
+            'Cache-Control': 'max-age=60',
+        }
         with patch.object(
             Session,
             'send',
@@ -317,10 +320,10 @@ class BaseCacheTest:
         assert r1.json() == r2.json()
 
     @pytest.mark.parametrize('decode_content', [True, False])
-    @pytest.mark.parametrize('body', ['string', 47, 47.1, True])
-    def test_decode_json_with_primitive_root(self, decode_content, body):
-        """Test that JSON responses (with primitive type root) are correctly returned from the
-        cache, regardless of `decode_content` setting"""
+    @pytest.mark.parametrize('body', ['string', 47, 47.1, True, '', [], {}])
+    def test_decode_json_root_types(self, decode_content, body):
+        """Test that JSON responses with an empty or primitive type root element are correctly
+        returned from the cache, regardless of `decode_content` setting"""
         session = self.init_session(decode_content=decode_content)
         session = mount_mock_adapter(session)
         url = 'http+mock://requests-cache.com/json_alt'


### PR DESCRIPTION
Fixes #963

This was a painful one. After a couple attempts at diving deep into debugging serialization logic and finding nothing, I later found that it was a simple case of testing `if x` instead of `if x is None`. 🤦