### PR TITLE
Ignore and log timezone errors when attempting to reuse responses cached in `requests-cache <= 1.1`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Add `verify` parameter to `BaseCache.contains()` and `delete()` to handle requests made with SSL verification disabled
+* Ignore and log timezone errors when attempting to reuse responses cached in `requests-cache <= 1.1`
 * Fix error handling with `stale_if_error` during revalidation requests
 * Remove `[bson]` package extra to prevent accidentally installing it in the same environment as `pymongo`
 

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -154,7 +154,11 @@ class CachedResponse(RichMixin, BaseResponse):
     @property
     def is_expired(self) -> bool:
         """Determine if this cached response is expired"""
-        return self.expires is not None and utcnow() >= self.expires
+        try:
+            return self.expires is not None and utcnow() >= self.expires
+        except TypeError as e:
+            logger.warning(e)
+            return True
 
     def is_older_than(self, older_than: ExpirationTime) -> bool:
         """Determine if this cached response is older than the given time"""

--- a/requests_cache/policy/expiration.py
+++ b/requests_cache/policy/expiration.py
@@ -90,6 +90,7 @@ def _parse_http_date(value: str) -> Optional[datetime]:
     try:
         expire_after = parsedate_to_datetime(value)
         return expire_after.astimezone(timezone.utc)
+    # Can occur when using a cache created with requests-cache <=1.1
     except (TypeError, ValueError):
         logger.debug(f'Failed to parse timestamp: {value}')
         return None

--- a/tests/unit/models/test_response.py
+++ b/tests/unit/models/test_response.py
@@ -6,11 +6,7 @@ import pytest
 from requests import Response
 from urllib3.response import HTTPResponse
 
-from requests_cache.models.response import (
-    CachedResponse,
-    OriginalResponse,
-    format_file_size,
-)
+from requests_cache.models.response import CachedResponse, OriginalResponse, format_file_size
 from requests_cache.policy import CacheActions, utcnow
 from tests.conftest import MOCKED_URL
 
@@ -68,6 +64,14 @@ def test_is_expired(expires, is_expired, mock_session):
     response = CachedResponse.from_response(mock_session.get(MOCKED_URL), expires=expires)
     assert response.from_cache is True
     assert response.is_expired == is_expired
+
+
+def test_is_expired__timezone_naive(mock_session):
+    response = CachedResponse.from_response(
+        mock_session.get(MOCKED_URL),
+        expires=datetime.now() - timedelta(days=1),
+    )
+    assert response.is_expired is True
 
 
 def test_iterator(mock_session):


### PR DESCRIPTION
Updates #973