### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
             '3.10',
             '3.11',
             '3.12',
+            '3.13',
             'pypy3.9-7.3.12',
             'pypy3.10-7.3.12',
           ]
@@ -41,6 +42,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - uses: snok/install-poetry@v1.4
         with:
           virtualenvs-in-project: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,6 +122,7 @@ jobs:
             '3.10',
             '3.11',
             '3.12',
+            '3.13',
             'pypy3.9-7.3.12',
             'pypy3.10-7.3.12',
           ]
@@ -173,6 +174,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - uses: snok/install-poetry@v1.4
         with:
           virtualenvs-in-project: true

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,8 @@
 * Remove `[bson]` package extra to prevent accidentally installing it in the same environment as `pymongo`
 * ⚠️ Changed behavior for `serializer='json'`, depending on installed packages:
   * Priority: `orjson` -> `ujson` -> stdlib `json`
-* Added the following serializers to explicitly use a specific JSON library: `json_serializer`, `ujson_serializer`, and `orjson_serializer`
+* Add the following serializers to explicitly use a specific JSON library: `json_serializer`, `ujson_serializer`, and `orjson_serializer`
+* Add support for Python 3.13
 
 ## 1.2.1 (2024-06-18)
 


### PR DESCRIPTION
Closes #<issue number>

<!--
If any of the items below don't apply to your PR, you can just remove them.
See the contributing guide for more info:
https://requests-cache.readthedocs.io/en/main/contributing.html
-->
### Checklist
- [n/a] Added docstrings and type annotations
- [x] Added test coverage
- [x] Updated changelog to describe any user-facing features or changed behavior

The Python 3.13 release candidate is out now! :rocket:

The Release Manager has issued a [call to action](https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703?u=hugovk]):

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.13 compatibilities during this phase, and where necessary publish Python 3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary wheels built against Python 3.13.0rc1 **will work** with future versions of Python 3.13. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).

