### PR TITLE
Changes to JSON and BSON serializers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 downloads/
 example_cache/
 http_cache/
+scratch/
 venv/
 
 *.db

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,16 +1,31 @@
 # History
 
-## Unreleased
-* Add `verify` parameter to `BaseCache.contains()` and `delete()` to handle requests made with SSL verification disabled
-* Ignore and log timezone errors when attempting to reuse responses cached in `requests-cache <= 1.1`
-* Fix error handling with `stale_if_error` during revalidation requests
+## 1.3.0 (Unreleased)
+
+⚠️ **Deprecations & removals:**
+* See changes to BSON and JSON serializers below:
+
+💾 **Serialization:**
+* ⚠️ Drop support for standalone `bson` codec; please install `pymongo` to use BSON serialization
 * Remove `[bson]` package extra to prevent accidentally installing it in the same environment as `pymongo`
-* ⚠️ Changed behavior for `serializer='json'`, depending on installed packages:
-  * Priority: `orjson` -> `ujson` -> stdlib `json`
-* Add the following serializers to explicitly use a specific JSON library: `json_serializer`, `ujson_serializer`, and `orjson_serializer`
+* When using BSON serialization with the filesystem backend, add a `.bson` file extension by default
+* ⚠️ `serializer='json'` will no longer automatically use `ultrajson` if installed; it must be specified explicitly
+* Add support for `orjson` as a JSON serializer
+  * However, see https://github.com/ijl/orjson/issues/483 for potential memory issues
+* Add the following serializer objects to specify a JSON library: `json_serializer`, `ujson_serializer`, and `orjson_serializer`
+* Remove `[json]` package extra due to multiple supported JSON libraries
+
+ℹ️ **Cache convenience methods:**
+* Add `verify` parameter to `BaseCache.contains()` and `delete()` to handle requests made with SSL verification disabled
+
+🧩 **Compatibility:**
 * Add support for Python 3.13
 
-## 1.2.1 (2024-06-18)
+🪲 **Bugfixes:**
+* Ignore and log timezone errors when attempting to reuse responses cached in `requests-cache <= 1.1`
+* Fix error handling with `stale_if_error` during revalidation requests
+
+### 1.2.1 (2024-06-18)
 
 🪲 **Bugfixes:**
 * Fix `normalize_headers` not accepting header values in bytes

--- a/docs/user_guide/serializers.md
+++ b/docs/user_guide/serializers.md
@@ -49,12 +49,7 @@ Usage:
 The alternative JSON libraries [`orjson`](https://github.com/ijl/orjson) and
 [`ultrajson`](https://github.com/ultrajson/ultrajson) are supported.
 
-The alias `serializer='json'` will use them in the following priority, if installed:
-* `orjson`
-* `ultrajson`
-* stdlib `json`
-
-Or, to be more explicit (recommended), use one of the following serializer objects:
+To use a specific JSON library, use one of the following serializer objects:
 ```py
 >>> from requests_cache import CachedSession, json_serializer ujson_serializer, orjson_serializer
 >>> session = CachedSession('my_cache', serializer=json_serializer)
@@ -106,26 +101,21 @@ MongoDB, but it can also be used independently. Compared to JSON, it has better 
 (although still not as fast as `pickle`), and adds support for additional data types. It is not
 human-readable, but some tools support reading and editing it directly.
 
-Usage:
+It is used by default for the MongoDB backend, but can be used with other backends, for example
+{py:class}`.FileCache`. Example:
 ```python
->>> session = CachedSession('my_cache', serializer='bson')
+>>> session = CachedSession('my_cache', backend='filesystem', serializer='bson')
 ```
 
 You can install the extra dependencies for this serializer with:
 ```bash
-pip install requests-cache[mongo]
+pip install requests-cache[mongodb]
 ```
 
 Or if you would like to use the standalone BSON codec for a different backend, without installing
 MongoDB dependencies:
-```bash
-pip install bson
-```
 
-```{warning}
-Only install the standalone `bson` package if you intend to use it without pymongo.
-Do not install both at the same time!
-```
+
 
 ## Response Content Format
 By default, any JSON or text response body will be decoded, so the response is fully

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ mongodb  = ["pymongo"]
 redis    = ["redis"]
 
 # Package extras for optional seriazliation dependencies
-json     = ["orjson"]  # Will optionally be used by JSON serializer for improved performance
 security = ["itsdangerous"]
 yaml     = ["pyyaml"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "requests-cache"
-version = "1.2.2"
+version = "1.3.0"
 description = "A persistent cache for python requests"
 authors = ["Roman Haritonov", "Jordan Cook"]
 license = "BSD-2-Clause"

--- a/requests_cache/backends/filesystem.py
+++ b/requests_cache/backends/filesystem.py
@@ -140,6 +140,7 @@ def _get_extension(extension: Optional[str] = None, serializer=None) -> str:
     if extension:
         return f'.{extension}'
     subs = {
+        'bson': 'bson',
         'safe_pickle': 'pkl',
         'pickle': 'pkl',
         'orjson': 'json',

--- a/requests_cache/serializers/__init__.py
+++ b/requests_cache/serializers/__init__.py
@@ -27,7 +27,6 @@ from .pipeline import SerializerPipeline, Stage
 from .preconf import (
     bson_document_serializer,
     bson_serializer,
-    default_json_serializer,
     dict_serializer,
     dynamodb_document_serializer,
     json_serializer,
@@ -53,7 +52,6 @@ __all__ = [
     'json_serializer',
     'orjson_serializer',
     'ujson_serializer',
-    'default_json_serializer',
     'pickle_serializer',
     'safe_pickle_serializer',
     'yaml_serializer',
@@ -62,7 +60,9 @@ __all__ = [
 
 SERIALIZERS = {
     'bson': bson_serializer,
-    'json': default_json_serializer,
+    'json': json_serializer,
+    'ujson': ujson_serializer,
+    'orjson': orjson_serializer,
     'pickle': pickle_serializer,
     'yaml': yaml_serializer,
 }

--- a/requests_cache/serializers/preconf.py
+++ b/requests_cache/serializers/preconf.py
@@ -79,25 +79,15 @@ except ImportError as e:
     safe_pickle_serializer = get_placeholder_class(e)  # noqa: F811
 
 
-# BSON/MongoDB document serializers
-def _get_bson_functions():
-    """Handle different function names between pymongo's bson and standalone bson"""
-    try:
-        import pymongo  # noqa: F401
-
-        return {'dumps': 'encode', 'loads': 'decode'}
-    except ImportError:
-        return {'dumps': 'dumps', 'loads': 'loads'}
-
-
+# BSON/MongoDB document serializer
 try:
     import bson
 
     bson_serializer = SerializerPipeline(
-        [bson_preconf_stage, Stage(bson, **_get_bson_functions())],
+        [bson_preconf_stage, Stage(bson, dumps='encode', loads='decode')],
         name='bson',
         is_binary=True,
-    )  #: Complete BSON serializer; uses pymongo's ``bson`` if installed, otherwise standalone ``bson`` codec
+    )  #: Complete BSON serializer
     bson_document_serializer = SerializerPipeline(
         [bson_preconf_stage],
         name='bson_document',

--- a/requests_cache/serializers/preconf.py
+++ b/requests_cache/serializers/preconf.py
@@ -98,13 +98,12 @@ except ImportError as e:
     bson_document_serializer = get_placeholder_class(e)
 
 
-# JSON serializer: stlib
+# JSON serializer: stdlib
 json_serializer = SerializerPipeline(
     [json_preconf_stage, Stage(dumps=partial(json.dumps, indent=2), loads=json.loads)],
     name='json',
     is_binary=False,
 )  #: Complete JSON serializer using stdlib json module
-default_json_serializer = json_serializer  #: Complete JSON serializer; uses orjson or ultrajson if available, otherwise stdlib json  # noqa: E501
 
 
 # JSON serializer: ultrajson
@@ -116,7 +115,6 @@ try:
         name='ujson',
         is_binary=False,
     )  #: Complete JSON serializer using ultrajson module
-    default_json_serializer = ujson_serializer
 except ImportError as e:
     ujson_serializer = get_placeholder_class(e)
 
@@ -133,7 +131,6 @@ try:
         name='orjson',
         is_binary=True,
     )  #: Complete JSON serializer using orjson module
-    default_json_serializer = orjson_serializer
 except ImportError as e:
     orjson_serializer = get_placeholder_class(e)
 

--- a/tests/integration/test_filesystem.py
+++ b/tests/integration/test_filesystem.py
@@ -106,6 +106,8 @@ class TestFileCache(BaseCacheTest):
             session.cache.responses[f'key_{i}'] = {f'value_{i}': i}
 
         expected_extension = serializer_name.replace('pickle', 'pkl')
+        if 'json' in serializer_name:
+            expected_extension = 'json'
         assert len(list(session.cache.paths())) == num_files
         for path in session.cache.paths():
             assert path.is_file()

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -19,50 +19,19 @@ from requests_cache import (
     json_serializer,
     safe_pickle_serializer,
     utf8_encoder,
+    init_serializer,
 )
 from tests.conftest import skip_missing_deps
 
 
 @skip_missing_deps('orjson')
-def test_json_default__orjson():
-    """1st priority JSON module: orjson"""
-    from requests_cache.serializers.preconf import default_json_serializer, orjson_serializer
-
-    assert default_json_serializer.name == 'orjson'
-    assert default_json_serializer is orjson_serializer
-
-
 @skip_missing_deps('ujson')
-def test_json_default__ujson():
-    """2nd priority JSON module: ultrajson"""
+def test_json_aliases():
+    from requests_cache.serializers.preconf import orjson_serializer, ujson_serializer
 
-    import requests_cache.serializers.preconf
-
-    with patch.dict(sys.modules, {'orjson': None, 'cattr.preconf.orjson': None}):
-        reload(requests_cache.serializers.preconf)
-        from requests_cache.serializers.preconf import default_json_serializer, ujson_serializer
-
-        assert default_json_serializer.name == 'ujson'
-        assert default_json_serializer is ujson_serializer
-
-    reload(requests_cache.serializers.preconf)
-
-
-def test_json_default__stdlib_json():
-    """3rd priority JSON module: stdlib JSON"""
-    import requests_cache.serializers.preconf
-
-    with patch.dict(
-        sys.modules,
-        {'ujson': None, 'cattr.preconf.ujson': None, 'orjson': None, 'cattr.preconf.orjson': None},
-    ):
-        reload(requests_cache.serializers.preconf)
-        from requests_cache.serializers.preconf import default_json_serializer, json_serializer
-
-        assert default_json_serializer.name == 'json'
-        assert default_json_serializer is json_serializer
-
-    reload(requests_cache.serializers.preconf)
+    assert init_serializer('json', decode_content=True) is json_serializer
+    assert init_serializer('orjson', decode_content=True) is orjson_serializer
+    assert init_serializer('ujson', decode_content=True) is ujson_serializer
 
 
 @skip_missing_deps('ujson')

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -1,7 +1,6 @@
 # Note: Almost all serializer logic is covered by parametrized integration tests.
 # Any additional serializer-specific tests can go here.
 import gzip
-import json
 import pickle
 import sys
 from importlib import reload
@@ -78,22 +77,6 @@ def test_json_explicit_lib():
     response = CachedResponse(status_code=200)
     for obj in [json_serializer, ujson_serializer, orjson_serializer]:
         assert obj.loads(obj.dumps(response)) == response
-
-
-@skip_missing_deps('bson')
-def test_standalone_bson():
-    """Handle different method names for standalone bson codec vs pymongo"""
-    import requests_cache.serializers.preconf
-
-    # Can't easily install both pymongo and bson (standalone) for tests;
-    # Using json module here since it has same functions as bson (standalone)
-    with patch.dict(sys.modules, {'bson': json, 'pymongo': None}):
-        reload(requests_cache.serializers.preconf)
-        bson_functions = requests_cache.serializers.preconf._get_bson_functions()
-
-        assert bson_functions == {'dumps': 'dumps', 'loads': 'loads'}
-
-    reload(requests_cache.serializers.preconf)
 
 
 def test_optional_dependencies():


### PR DESCRIPTION
Closes #951; follow-up from #994, #997, #999

* Remove automatic selection of JSON library; require specifying it explicitly
* Drop support for standalone `bson` codec; require pymongo's `bson` module
* Use `.bson` file extension by default when using BSON serializer with filesystem backend
* Remove `[bson]` and `[json]` package extras