### PR TITLE
Fix request headers sent when `expire_after` is set to `DO_NOT_CACHE`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,6 +29,7 @@
 * Ignore and log timezone errors when attempting to reuse responses cached in `requests-cache <= 1.1`
 * Fix error handling with `stale_if_error` during revalidation requests
 * By default, do not automatically close backend connections when using `install_cache()`
+* Fix request headers sent when `expire_after` is set to `DO_NOT_CACHE`
 
 ### 1.2.1 (2024-06-18)
 

--- a/requests_cache/policy/expiration.py
+++ b/requests_cache/policy/expiration.py
@@ -11,7 +11,7 @@ from typing import Pattern as RegexPattern
 from .._utils import try_int
 from . import ExpirationPattern, ExpirationPatterns, ExpirationTime
 
-# Special expiration values that may be set by either headers or keyword args
+# Special client-side expiration values that may be set by either headers or keyword args
 DO_NOT_CACHE = 0x0D0E0200020704  # Per RFC 4824
 EXPIRE_IMMEDIATELY = 0
 NEVER_EXPIRE = -1
@@ -51,8 +51,6 @@ def get_expiration_datetime(
 
 def get_expiration_seconds(expire_after: ExpirationTime) -> int:
     """Convert an expiration value in any supported format to an expiration time in seconds"""
-    if expire_after == DO_NOT_CACHE:
-        return DO_NOT_CACHE
     expires = get_expiration_datetime(expire_after, ignore_invalid_httpdate=True)
     return ceil((expires - utcnow()).total_seconds()) if expires else NEVER_EXPIRE
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -722,6 +722,8 @@ def test_do_not_cache(mock_session):
     # Skip read
     response = mock_session.get(MOCKED_URL, expire_after=DO_NOT_CACHE)
     assert response.from_cache is False
+    # Internal value only; should not be sent to server
+    assert 'Cache-Control' not in response.request.headers
 
     # Skip write
     mock_session.settings.expire_after = DO_NOT_CACHE


### PR DESCRIPTION
Closes #1014

This ensures that `DO_NOT_CACHE` remains an internal value only and isn't sent in request headers. The challenge here was that there is no way to pass extra arbitrary parameters from `CachedSession.request()` -> `Session.request()` -> `CachedSession.send()`, so `DO_NOT_CACHE` was being passed via `Cache-Control: max-age` (same as any other per-request `expire_after` value).

This PR's inelegant solution is to pass this value via an arbitrary, non-standard header `X-ACTUAL-NO-CACHE` (not to be confused with `Cache-Control: no-cache`... which of course doesn't actually mean what it says), and then remove it in `CachedSession.send()` before sending the actual request.

If anyone has ideas for a better way to accomplish this, I'm open to suggestions!
