### PR TITLE
Improve type hinting by also allowing `Path`s to be correct when installing the cache

### DIFF
--- a/requests_cache/patcher.py
+++ b/requests_cache/patcher.py
@@ -15,14 +15,14 @@ from typing import Optional, Type
 
 import requests
 
-from .backends import BackendSpecifier, BaseCache, init_backend
+from .backends import BackendSpecifier, BaseCache, init_backend, StrOrPath
 from .session import CachedSession, OriginalSession
 
 logger = getLogger(__name__)
 
 
 def install_cache(
-    cache_name: str = 'http_cache',
+    cache_name: StrOrPath = 'http_cache',
     backend: Optional[BackendSpecifier] = None,
     session_factory: Type[OriginalSession] = CachedSession,
     **kwargs,


### PR DESCRIPTION
In my IDE this line was nagging me, and I saw that `install_cache` only accepted a `str`. But both `init_backend` and `CacheMixin` allows a `StrOrPath` as their input.

So this one brings the typing in line with the methods that are being called (and stopping my IDE warning not to provide paths ;)).