### PR TITLE
Wrong link corrected in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Closes #<issue number>
 <!--
 If any of the items below don't apply to your PR, you can just remove them.
 See the contributing guide for more info:
-https://requests-cache.readthedocs.io/en/main/contributing.html
+https://requests-cache.readthedocs.io/en/main/project_info/contributing.html
 -->
 ### Checklist
 - [ ] Added docstrings and type annotations


### PR DESCRIPTION
Inside the PR template there was a wrong link present (I checked during the creation of my previous one).
As that was unrelated to that PR, creating one to correct the link.