### PR TITLE
Add `autoclose` option to close backend connections when the session is closed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,9 @@
 * Remove `[json]` package extra due to multiple supported JSON libraries
 * Allow `decode_content` to be set to different values across multiple sessions in use at the same time
 
+⚙️ **Session settings:**
+* Add `autoclose` option to close backend connections when the session is closed
+
 ℹ️ **Cache convenience methods:**
 * Add `verify` parameter to `BaseCache.contains()` and `delete()` to handle requests made with SSL verification disabled
 
@@ -25,6 +28,7 @@
 🪲 **Bugfixes:**
 * Ignore and log timezone errors when attempting to reuse responses cached in `requests-cache <= 1.1`
 * Fix error handling with `stale_if_error` during revalidation requests
+* By default, do not automatically close backend connections when using `install_cache()`
 
 ### 1.2.1 (2024-06-18)
 

--- a/requests_cache/patcher.py
+++ b/requests_cache/patcher.py
@@ -42,6 +42,10 @@ def install_cache(
     """
     backend = init_backend(cache_name, backend, **kwargs)
 
+    # By default, don't close backend connections when the session is closed,
+    # since request.get(), etc. will create and close a new session object for each request
+    kwargs.setdefault('autoclose', False)
+
     class _ConfiguredCachedSession(session_factory):  # type: ignore  # See mypy issue #5865
         def __init__(self):
             super().__init__(cache_name=cache_name, backend=backend, **kwargs)

--- a/requests_cache/policy/settings.py
+++ b/requests_cache/policy/settings.py
@@ -26,6 +26,7 @@ class CacheSettings(RichMixin):
     allowable_codes: Iterable[int] = field(default=DEFAULT_STATUS_CODES)
     allowable_methods: Iterable[str] = field(default=DEFAULT_METHODS)
     always_revalidate: bool = field(default=False)
+    autoclose: bool = field(default=True)
     cache_control: bool = field(default=False)
     disabled: bool = field(default=False)
     expire_after: ExpirationTime = field(default=None)

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -33,6 +33,7 @@ def test_session_settings():
     assert patched_session.settings.expire_after == 360
     assert patched_session.settings.cache_control is True
     assert patched_session.settings.allowable_codes == (200, 301)
+    assert patched_session.settings.autoclose is False
 
     requests_cache.uninstall_cache()
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1102,3 +1102,18 @@ def test_send_and_cache__already_cached(mock_send, mock_session):
         CachedResponse(),
     )
     assert r1 is r2
+
+
+def test_close(mock_session):
+    """By default, backend connections should be closed when the session closes"""
+    with patch.object(mock_session.cache, 'close') as mock_close:
+        mock_session.close()
+        mock_close.assert_called_once()
+
+
+def test_close__autoclose_off(mock_session):
+    """With autoclose=False, backend connections should NOT be closed when the session closes"""
+    mock_session.settings.autoclose = False
+    with patch.object(mock_session.cache, 'close') as mock_close:
+        mock_session.close()
+        mock_close.assert_not_called()


### PR DESCRIPTION
Fixes #1034

* Defaults to `True` when using `CachedSession` (typically long-lived session objects; same as current behavior)
* Defaults to `False` when using `install_cache()` (short-lived session objects, one per request; changed behavior)