### PR TITLE
Reorder development setup

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,6 +30,7 @@
 * Fix error handling with `stale_if_error` during revalidation requests
 * By default, do not automatically close backend connections when using `install_cache()`
 * Fix request headers sent when `expire_after` is set to `DO_NOT_CACHE`
+* Reorder development setup steps to make tests run (green) as expected
 
 ### 1.2.1 (2024-06-18)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,12 +108,9 @@ def httpbin(path):
     return f'{base_url}/{path}'
 
 
-try:
+USE_PYTEST_HTTPBIN = os.getenv('USE_PYTEST_HTTPBIN', '').lower() == 'true'
+if USE_PYTEST_HTTPBIN:
     import pytest_httpbin  # noqa: F401
-
-    USE_PYTEST_HTTPBIN = os.getenv('USE_PYTEST_HTTPBIN', '').lower() == 'true'
-except ImportError:
-    USE_PYTEST_HTTPBIN = False
 
 
 @pytest.fixture(scope='session', autouse=USE_PYTEST_HTTPBIN)


### PR DESCRIPTION
This re-orders the development setup so that all commands should run successfully. Also USE_PYTEST_HTTP_BIN now raises an error if not installed but in use.

Closes #1056 

Obsoletes #1051

<!--
If any of the items below don't apply to your PR, you can just remove them.
See the contributing guide for more info:
https://requests-cache.readthedocs.io/en/main/project_info/contributing.html
-->
### Checklist
- [x] Added docstrings and type annotations
- [x] Added test coverage
- [x] Updated changelog to describe any user-facing features or changed behavior
