### PR TITLE
When updating response headers after revalidating a cached response, don't set both `Content-Length` and `Transfer-Encoding`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -45,6 +45,7 @@
 * Fix error handling with `stale_if_error` during revalidation requests
 * By default, do not automatically close backend connections when using `install_cache()`
 * Fix request headers sent when `expire_after` is set to `DO_NOT_CACHE`
+* When updating response headers after revalidating a cached response, don't set both `Content-Length` and `Transfer-Encoding`
 
 ### 1.2.1 (2024-06-18)
 

--- a/requests_cache/policy/actions.py
+++ b/requests_cache/policy/actions.py
@@ -265,9 +265,17 @@ class CacheActions(RichMixin):
             cached_response.headers.get(k) != v for k, v in response.headers.items()
         )
         self.skip_write = self.expires == cached_response.expires and not headers_changed
-
         cached_response.expires = self.expires
+
+        # Update headers;
+        # Account for Transfer-Encoding in original response and Content-Length in 304 response
         cached_response.headers.update(response.headers)
+        if (
+            'Content-Length' in cached_response.headers
+            and 'Transfer-Encoding' in cached_response.headers
+        ):
+            del cached_response.headers['Content-Length']
+
         cached_response.revalidated = True
         return cached_response
 

--- a/requests_cache/serializers/cattrs.py
+++ b/requests_cache/serializers/cattrs.py
@@ -203,8 +203,11 @@ def _encode_content(response: CachedResponse) -> CachedResponse:
     if isinstance(response._decoded_content, str):
         response._content = response._decoded_content.encode('utf-8')
         response._decoded_content = None
-        response.encoding = 'utf-8'  # Set encoding explicitly so requests doesn't have to detect it
-        response.headers['Content-Length'] = str(len(response._content))  # Size may have changed
+        # Set encoding explicitly so requests doesn't have to detect it
+        response.encoding = 'utf-8'
+        # Normalization may change Content-Length
+        if 'Content-Length' in response.headers:
+            response.headers['Content-Length'] = str(len(response._content))
 
     return response
 


### PR DESCRIPTION
Fixes #1067 