### PR TITLE
Use ECR instead of Docker Hub for integration test containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,12 @@ jobs:
       # Start integration test databases
       - uses: supercharge/mongodb-github-action@1.12.0
         with:
-          mongodb-version: 5.0
+          mongodb-image: public.ecr.aws/docker/library/mongo
+          mongodb-version: 8
       - uses: supercharge/redis-github-action@1.8.0
         with:
-          redis-version: 6
+          redis-image: public.ecr.aws/docker/library/redis
+          redis-version: 7
       - uses: rrainn/dynamodb-action@v4.0.0
 
       # Run tests with coverage report

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,12 +54,14 @@ jobs:
           uv sync --all-extras
 
       # Start integration test databases
-      - uses: supercharge/mongodb-github-action@1.11.0
+      - uses: supercharge/mongodb-github-action@1.12.0
         with:
-          mongodb-version: 5.0
+          mongodb-image: public.ecr.aws/docker/library/mongo
+          mongodb-version: 8
       - uses: supercharge/redis-github-action@1.8.0
         with:
-          redis-version: 6
+          redis-image: public.ecr.aws/docker/library/redis
+          redis-version: 7
       - uses: rrainn/dynamodb-action@v4.0.0
 
       # Run tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - '8080:80'
 
   dynamodb:
-    image: amazon/dynamodb-local
+    image: public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local
     container_name: dynamodb-test
     ports:
       - '8000:8000'
@@ -18,18 +18,18 @@ services:
     working_dir: '/home/dynamodblocal'
 
   mongo:
-    image: mongo
+    image: public.ecr.aws/bitnami/mongodb
     container_name: mongo-test
     environment:
       MONGO_INITDB_DATABASE: 'requests_cache_pytest'
     ports:
       - '27017:27017'
     volumes:
-      - 'mongodb_data:/data/db'
+      - 'mongodb_data:/bitnami/mongodb'
 
   redis:
+    image: public.ecr.aws/bitnami/redis
     container_name: redis-test
-    image: docker.io/bitnami/redis
     ports:
       - '6379:6379'
     environment:
@@ -38,7 +38,7 @@ services:
       - 'redis_data:/bitnami/redis/data'
 
   valkey:
-    image: docker.io/bitnami/valkey:8.0
+    image: public.ecr.aws/bitnami/valkey
     container_name: valkey-test
     environment:
       ALLOW_EMPTY_PASSWORD: 'yes'


### PR DESCRIPTION
Exception: There is a DynamoDB container on ECR (obviously!), but there isn't a GitHub Action that uses it or can be configured to use it.

This is to avoid Docker Hub rate limits, which are currently resulting in flaky tests, and will be [decreasing to 10 pulls/hour on April 1](https://docs.docker.com/docker-hub/usage/).