### PR TITLE
Fix SQLite concurrency on python 3.12+

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -41,6 +41,7 @@
   * For developers, see [Contributing Guide](https://requests-cache.readthedocs.io/en/stable/project_info/contributing.html) for details
 
 🪲 **Bugfixes:**
+* Fix `sqlite3.InterfaceError: bad parameter or other API misuse` with concurrent SQLite usage in python 3.12+
 * Ignore and log timezone errors when attempting to reuse responses cached in `requests-cache <= 1.1`
 * Fix error handling with `stale_if_error` during revalidation requests
 * By default, do not automatically close backend connections when using `install_cache()`

--- a/requests_cache/backends/sqlite.py
+++ b/requests_cache/backends/sqlite.py
@@ -327,7 +327,9 @@ class SQLiteDict(BaseStorage):
 
     def __getitem__(self, key):
         with self.connection() as con:
-            cur = con.execute(f'SELECT value FROM {self.table_name} WHERE key=?', (key,))
+            # Using placeholders here with python 3.12+ and concurrency results in the error:
+            # sqlite3.InterfaceError: bad parameter or other API misuse
+            cur = con.execute(f"SELECT value FROM {self.table_name} WHERE key='{key}'")
             row = cur.fetchone()
             cur.close()
             if not row:

--- a/tests/integration/test_filesystem.py
+++ b/tests/integration/test_filesystem.py
@@ -1,6 +1,4 @@
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from shutil import rmtree
-from sys import version_info
 from tempfile import gettempdir
 from threading import RLock
 from typing import Generator
@@ -19,7 +17,7 @@ from requests_cache.serializers import (
     yaml_serializer,
     utf8_serializer,
 )
-from tests.conftest import HTTPBIN_FORMATS, HTTPBIN_METHODS, N_ITERATIONS
+from tests.conftest import HTTPBIN_FORMATS, HTTPBIN_METHODS
 from tests.integration.base_cache_test import BaseCacheTest
 from tests.integration.base_storage_test import CACHE_NAME, BaseStorageTest
 
@@ -204,14 +202,6 @@ class TestFileCache(BaseCacheTest):
 
         # Redirects db should be in the same directory as response files
         assert session.cache.redirects.db_path.parent == session.cache.responses.cache_dir
-
-    # TODO: Remove after fixing issue with SQLite multiprocessing on python 3.12
-    @pytest.mark.parametrize('executor_class', [ThreadPoolExecutor, ProcessPoolExecutor])
-    @pytest.mark.parametrize('iteration', range(N_ITERATIONS))
-    def test_concurrency(self, iteration, executor_class):
-        if version_info >= (3, 12):
-            pytest.xfail('Concurrent usage of SQLite backend is not yet supported on python 3.12')
-        super().test_concurrency(iteration, executor_class)
 
     @pytest.mark.parametrize('maximum_size_on_disk', [1000, 10000])
     @pytest.mark.parametrize('files_on_disk', [3, 100])

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -1,10 +1,8 @@
 import os
 import pickle
 import sqlite3
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from datetime import timedelta
 from os.path import join
-from sys import version_info
 from tempfile import NamedTemporaryFile, gettempdir
 from threading import Thread
 from unittest.mock import patch
@@ -16,7 +14,7 @@ from requests_cache.backends import BaseCache, SQLiteCache, SQLiteDict
 from requests_cache.backends.sqlite import MEMORY_URI
 from requests_cache.models import CachedResponse
 from requests_cache.policy import utcnow
-from tests.conftest import N_ITERATIONS, skip_pypy
+from tests.conftest import skip_pypy
 from tests.integration.base_cache_test import BaseCacheTest
 from tests.integration.base_storage_test import CACHE_NAME, BaseStorageTest
 
@@ -414,11 +412,3 @@ class TestSQLiteCache(BaseCacheTest):
             assert prev_item is None or prev_item.expires < item.expires
             assert item.cache_key
             assert not item.is_expired
-
-    # TODO: Remove after fixing issue with SQLite multiprocessing on python 3.12
-    @pytest.mark.parametrize('executor_class', [ThreadPoolExecutor, ProcessPoolExecutor])
-    @pytest.mark.parametrize('iteration', range(N_ITERATIONS))
-    def test_concurrency(self, iteration, executor_class):
-        if version_info >= (3, 12):
-            pytest.xfail('Concurrent usage of SQLite backend is not yet supported on python 3.12')
-        super().test_concurrency(iteration, executor_class)


### PR DESCRIPTION
Closes #845

This is a workaround to resolve `sqlite3.InterfaceError: bad parameter or other API misuse` errors when using the SQLite backend concurrently on python 3.12.  This doesn't quite address the root cause, which is still baffling to me. I suspect it's a bug in the cpython `sqlite` module, but I don't have the capability to debug further.

This uses string formatting instead of DBAPI parameter placeholders, which generally isn't good practice, but I believe there is no practical risk of SQL injection since it's just inserting cache keys generated by the library itself.