### PR TITLE
for Expires, an invalid date must be treated as 'already expired'

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -50,6 +50,7 @@
 * Fix request headers sent when `expire_after` is set to `DO_NOT_CACHE`
 * Show a warning when initializing a cache with both `cache_name` and a backend instance (database names, file paths, etc. cannot be reliably updated after initialization)
 * When updating response headers after revalidating a cached response, don't set both `Content-Length` and `Transfer-Encoding`
+* Treat invalid HTTP dates (eg. 'Expires: 0' and 'Expires: -1') as 'already expired' as per RFC 2616, section 14.21
 
 ### 1.2.1 (2024-06-18)
 

--- a/requests_cache/policy/expiration.py
+++ b/requests_cache/policy/expiration.py
@@ -26,6 +26,13 @@ def get_expiration_datetime(
     ignore_invalid_httpdate: bool = False,
 ) -> Optional[datetime]:
     """Convert an expiration value in any supported format to an absolute datetime"""
+    # Invalid dates MUST be treated as 'already expired' (RFC 2616, section 14.21)
+    # Expires headers arrive as integer strings (eg. '0'...or even '-1' if you are Azure...)
+    if (
+        isinstance(expire_after, str)
+        and (expire_after[1:] if expire_after[0] == '-' else expire_after).isdigit()
+    ):
+        expire_after = EXPIRE_IMMEDIATELY
     # Never expire (or do not cache, in which case expiration won't be used)
     if expire_after is None or expire_after in [NEVER_EXPIRE, DO_NOT_CACHE]:
         return None

--- a/tests/unit/policy/test_expiration.py
+++ b/tests/unit/policy/test_expiration.py
@@ -20,6 +20,10 @@ def test_get_expiration_datetime__no_expiration(mock_datetime):
     assert get_expiration_datetime(None) is None
     assert get_expiration_datetime(-1) is None
     assert get_expiration_datetime(EXPIRE_IMMEDIATELY) == mock_datetime.now(timezone.utc)
+    # test 'Expires: 0' (str)
+    assert get_expiration_datetime('0') is mock_datetime.now(timezone.utc)
+    # test 'Expires: -1' (str) - Azure silliness
+    assert get_expiration_datetime('-1') is mock_datetime.now(timezone.utc)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1090

Debating about how to fix this as this function looks to be used for headers other than just expires.

Originally I just amended the ValueError to `return start_time or utcnow()` but you seem to want this behaviour according to your unit tests so instead I went with a 'pre-massaging' step to change integer strings to `EXPIRE_IMMEDIATELY`.

### Checklist
- [X] Added test coverage
- [X] Updated changelog to describe any user-facing features or changed behavior
