### PR TITLE
Switch from httpbin Docker image to go-httpbin for arm64/Apple silicon support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
     services:
       nginx:
-        image: kennethreitz/httpbin
+        image: mccutchen/go-httpbin
         ports:
-          - 8080:80
+          - 8080:8080
 
     steps:
       # Install dependencies, with caching

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,9 +37,9 @@ jobs:
 
     services:
       nginx:
-        image: kennethreitz/httpbin
+        image: mccutchen/go-httpbin
         ports:
-          - 8080:80
+          - 8080:8080
 
     steps:
       # Install dependencies, with caching

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 # Containers needed to test all backend services locally
 services:
   httpbin:
-    image: kennethreitz/httpbin
+    image: mccutchen/go-httpbin
     container_name: httpbin
     ports:
-      - '8080:80'
+      - '8080:8080'
 
   dynamodb:
     image: amazon/dynamodb-local

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,6 @@ N_REQUESTS_PER_ITERATION = 10 + 10 * STRESS_TEST_MULTIPLIER
 HTTPBIN_DEFAULT = 'http://localhost:8080'
 HTTPBIN_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
 HTTPBIN_FORMATS = [
-    'brotli',
     'deflate',
     'deny',
     'encoding/utf8',

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -143,7 +143,7 @@ class BaseCacheTest:
         def get_json(url):
             return json.loads(session.get(url).text)
 
-        response_1 = get_json(httpbin('cookies/set/test1/test2'))
+        response_1 = get_json(httpbin('cookies/set?test1=test2'))
         with session.cache_disabled():
             assert get_json(httpbin('cookies')) == response_1
 
@@ -153,7 +153,7 @@ class BaseCacheTest:
 
         # Not from cache
         with session.cache_disabled():
-            response_3 = get_json(httpbin('cookies/set/test3/test4'))
+            response_3 = get_json(httpbin('cookies/set?test3=test4'))
             assert response_3 == get_json(httpbin('cookies'))
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1085

Minor differences:
* default port is 8080, not 80
* `/cookies` endpoint uses request params instead of paths to set cookie values (e.g., `/cookies/set/k/v` -> `/cookies/set?k=v`)
* does not have brotli support