### PR TITLE
Use SHA256 as a fallback hashing algorithm on FIPS-enabled systems

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,6 +37,7 @@
 🧩 **Compatibility and packaging:**
 * Add support for Python 3.13
 * Add compatibility with url-normalize 2.0
+* Add compatibility with FIPS-compliant systems
 * Packaging and project config are now managed by uv
   * This has no impact for users; installation from PyPI still works the same
   * For developers, see [Contributing Guide](https://requests-cache.readthedocs.io/en/stable/project_info/contributing.html) for details


### PR DESCRIPTION
This implementation allows to use requests_cache on any FIPS-compliant systems and systems where limited OpenSSL blake2b implementation is invoked.

Note: there is `usedforsecurity` keyword argument for hashlib that can allow usage of `blake2b` on FIPS-compliant systems, but  1) it requires Python 3.9 and 2) it does not solve the issue with lacking OpenSSL blake2b implementation.

<!--
If any of the items below don't apply to your PR, you can just remove them.
See the contributing guide for more info:
https://requests-cache.readthedocs.io/en/main/project_info/contributing.html
-->
### Checklist
- [ ] Added docstrings and type annotations
- [ ] Added test coverage
- [x] Updated changelog to describe any user-facing features or changed behavior
