### PR TITLE
feat: make table creation optional

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,8 @@
   * Add `lock` parameter to specify a custom lock object
 * **Redis:**
     * For maintenance/inspection methods that iterate over the cache, use `SCAN` and `HSCAN` instead of `KEYS`, `HKEYS`, and `HGETALL`
+* **DynamoDB**
+  * Add optional parameter `create_table` of `DynamoDBCache` to control if the class attempts to create the table in DynamoDB or not.
 
 ⚙️ **Session settings:**
 * Add `autoclose` option to close backend connections when the session is closed

--- a/docs/user_guide/backends/dynamodb.md
+++ b/docs/user_guide/backends/dynamodb.md
@@ -96,6 +96,11 @@ want to quickly test out DynamoDB as a cache backend, but in a production enviro
 likely want to create the tables yourself, for example with
 [CloudFormation](https://aws.amazon.com/cloudformation/) or [Terraform](https://www.terraform.io/).
 
+If you don't want requests-cache to automatically create the dynamodb table you can pass in an optional parameter.
+```python
+>>> backend = DynamoDbCache(create_table=False)
+```
+
 You just need a table with a single partition key. A `value` attribute (containing response data)
 will be created dynamically once items are added to the table.
 - Table: `http_cache` (or any other name, as long as it matches the `table_name` parameter for `DynamoDbCache`)

--- a/requests_cache/backends/dynamodb.py
+++ b/requests_cache/backends/dynamodb.py
@@ -34,6 +34,7 @@ class DynamoDbCache(BaseCache):
     def __init__(
         self,
         table_name: str = 'http_cache',
+        create_table: bool = True,
         *,
         ttl: bool = True,
         connection: Optional[ServiceResource] = None,
@@ -45,6 +46,7 @@ class DynamoDbCache(BaseCache):
         skwargs = {'serializer': serializer, **kwargs} if serializer else kwargs
         self.responses = DynamoDbDict(
             table_name,
+            create_table=create_table,
             ttl=ttl,
             connection=connection,
             decode_content=decode_content,
@@ -68,6 +70,7 @@ class DynamoDbDict(BaseStorage):
     def __init__(
         self,
         table_name: str,
+        create_table: bool = True,
         ttl: bool = True,
         connection: Optional[ServiceResource] = None,
         serializer: Optional[SerializerType] = dynamodb_document_serializer,
@@ -82,7 +85,8 @@ class DynamoDbDict(BaseStorage):
         self.ttl = ttl
 
         self._table = self.connection.Table(self.table_name)
-        self._create_table()
+        if create_table:
+            self._create_table()
         if ttl:
             self._enable_ttl()
 

--- a/requests_cache/backends/dynamodb.py
+++ b/requests_cache/backends/dynamodb.py
@@ -25,6 +25,7 @@ class DynamoDbCache(BaseCache):
 
     Args:
         table_name: DynamoDB table name
+        create_table: Whether or not to automatically create the dynamo backend table. 
         connection: :boto3:`DynamoDB Resource <services/dynamodb/service-resource/index.html#service-resource>`
             object to use instead of creating a new one
         ttl: Use DynamoDB TTL to automatically remove expired items
@@ -61,6 +62,7 @@ class DynamoDbDict(BaseStorage):
 
     Args:
         table_name: DynamoDB table name
+        create_table: Whether or not to automatically create the dynamo backend table. 
         connection: :boto3:`DynamoDB Resource <services/dynamodb/service-resource/index.html#service-resource>`
             object to use instead of creating a new one
         ttl: Use DynamoDB TTL to automatically remove expired items

--- a/requests_cache/backends/dynamodb.py
+++ b/requests_cache/backends/dynamodb.py
@@ -25,7 +25,7 @@ class DynamoDbCache(BaseCache):
 
     Args:
         table_name: DynamoDB table name
-        create_table: Whether or not to automatically create the dynamo backend table. 
+        create_table: Whether or not to automatically create the dynamo backend table.
         connection: :boto3:`DynamoDB Resource <services/dynamodb/service-resource/index.html#service-resource>`
             object to use instead of creating a new one
         ttl: Use DynamoDB TTL to automatically remove expired items
@@ -62,7 +62,7 @@ class DynamoDbDict(BaseStorage):
 
     Args:
         table_name: DynamoDB table name
-        create_table: Whether or not to automatically create the dynamo backend table. 
+        create_table: Whether or not to automatically create the dynamo backend table.
         connection: :boto3:`DynamoDB Resource <services/dynamodb/service-resource/index.html#service-resource>`
             object to use instead of creating a new one
         ttl: Use DynamoDB TTL to automatically remove expired items

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -45,7 +45,11 @@ class TestDynamoDbDict(BaseStorageTest):
         DynamoDbDict('test_table', region_name='us-east-2', invalid_kwarg='???')
         mock_resource.assert_called_with('dynamodb', region_name='us-east-2')
 
-    def test_create_table_error(self):
+    @patch('requests_cache.backends.dynamodb.boto3.resource')
+    def test_no_create_table(self, mock_resource):
+        DynamoDbDict('test_table', region_name='us-east-2', create_table=False)
+        self.assetEquals(mock_resource.create_table.call_count, 0)
+    def test_enable_ttl_error(self):
         """An error other than 'table already exists' should be reraised"""
         from botocore.exceptions import ClientError
 
@@ -55,7 +59,7 @@ class TestDynamoDbDict(BaseStorageTest):
             with pytest.raises(ClientError):
                 cache._enable_ttl()
 
-    def test_enable_ttl_error(self):
+    def test_create_table_error(self):
         """An error other than 'ttl already enabled' should be reraised"""
         from botocore.exceptions import ClientError
 

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -49,6 +49,7 @@ class TestDynamoDbDict(BaseStorageTest):
     def test_no_create_table(self, mock_resource):
         DynamoDbDict('test_table', region_name='us-east-2', create_table=False)
         self.assetEquals(mock_resource.create_table.call_count, 0)
+
     def test_enable_ttl_error(self):
         """An error other than 'table already exists' should be reraised"""
         from botocore.exceptions import ClientError

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -48,7 +48,7 @@ class TestDynamoDbDict(BaseStorageTest):
     @patch('requests_cache.backends.dynamodb.boto3.resource')
     def test_no_create_table(self, mock_resource):
         DynamoDbDict('test_table', region_name='us-east-2', create_table=False)
-        self.assetEquals(mock_resource.create_table.call_count, 0)
+        assert mock_resource.create_table.call_count == 0
 
     def test_enable_ttl_error(self):
         """An error other than 'table already exists' should be reraised"""


### PR DESCRIPTION
This is a backwards compatible change that makes dynamodb table creation optional. Will high levels of load this was leading to API throttling errors for the dynamodb create table api. Solves https://github.com/requests-cache/requests-cache/issues/1027

Closes #1027

<!--
If any of the items below don't apply to your PR, you can just remove them.
See the contributing guide for more info:
https://requests-cache.readthedocs.io/en/main/project_info/contributing.html
-->
### Checklist
- [x] Added docstrings and type annotations
- [x] Updated changelog to describe any user-facing features or changed behavior
