### PR TITLE
Fix flaky tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,9 @@ jobs:
       # Run tests with coverage report
       - name: Run unit + integration tests
         if: ${{ !contains(matrix.python-version, 'pypy') }}
-        run: uv run nox -e cov -- xml
+        run: |
+          uv run nox -e cov -- xml
+          uv run nox -e stress -- 1
 
       # pypy tests aren't run in parallel, so too slow for integration tests
       - name: Run unit tests only

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,11 +84,15 @@ def clean(session):
 @nox.session(python=False, name='cov')
 def coverage(session):
     """Run tests and generate coverage report"""
-    cmd = ['pytest', *ALL_TESTS, '-rsxX', '--cov']
+    cmd = ['pytest', *ALL_TESTS, '-rsxX']
+
+    # Exclude concurrency tests to run separately without xdist
+    cmd += ['-k', 'not concurrency']
     if not IS_PYPY:
         cmd += XDIST_ARGS
 
     # Add coverage formats
+    cmd += ['--cov']
     cov_formats = session.posargs or DEFAULT_COVERAGE_FORMATS
     cmd += [f'--cov-report={f}' for f in cov_formats]
 


### PR DESCRIPTION
In CI, SQLite concurrency tests recently started failing on python 3.13 (Disk or other I/O errors), and concurrency tests for a few other backends are occasionally flaky in general. Running these tests separately without xdist appears to fix or reduce this.