### PR TITLE
Run tests for python 3.14 and fix multiprocessing `PicklingError`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,17 @@ jobs:
     strategy:
       matrix:
         python-version:
-          ['3.13', '3.12', '3.11', '3.10', '3.9', '3.8', 'pypy3.9', 'pypy3.10']
+          [
+            '3.13',
+            '3.12',
+            '3.11',
+            '3.10',
+            '3.9',
+            '3.8',
+            '3.14-rc2',
+            'pypy3.9',
+            'pypy3.10',
+          ]
       fail-fast: false
     services:
       nginx:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,7 +37,7 @@
 * Add `verify` parameter to `BaseCache.contains()` and `delete()` to handle requests made with SSL verification disabled
 
 🧩 **Compatibility and packaging:**
-* Add support for Python 3.13
+* Add support for Python 3.13 and 3.14
 * Add compatibility with url-normalize 2.0
 * Add compatibility with FIPS-compliant systems
     * Note: Due to using a different hashing algorithm for cache keys, caches cannot be shared between FIPS- and non-FIPS-compliant systems

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ dev = [
     'requests-mock          ~=1.12',
     'responses              >=0.19',
     'tenacity               ~=8.0',
-    'timeout-decorator      ~=0.5',
     'time-machine           ~=2.9; implementation_name != "pypy"',
     'nox                    >=2024.4',
     'pre-commit             >=3.5',

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -27,7 +27,10 @@ def ensure_connection():
     from pymongo import MongoClient
 
     client = MongoClient(serverSelectionTimeoutMS=2000)
-    client.server_info()
+    try:
+        client.server_info()
+    finally:
+        client.close()
 
 
 class TestMongoDict(BaseStorageTest):

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -15,7 +15,11 @@ def ensure_connection():
     """Fail all tests in this module if Redis is not running"""
     from redis import Redis
 
-    Redis().info()
+    client = Redis()
+    try:
+        client.info()
+    finally:
+        client.close()
 
 
 class TestRedisDict(BaseStorageTest):

--- a/uv.lock
+++ b/uv.lock
@@ -1789,7 +1789,6 @@ dev = [
     { name = "tenacity" },
     { name = "time-machine", version = "2.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9' and implementation_name != 'pypy'" },
     { name = "time-machine", version = "2.19.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and implementation_name != 'pypy'" },
-    { name = "timeout-decorator" },
 ]
 docs = [
     { name = "furo", marker = "python_full_version >= '3.11'" },
@@ -1850,7 +1849,6 @@ dev = [
     { name = "rich", specifier = ">=10.0" },
     { name = "tenacity", specifier = "~=8.0" },
     { name = "time-machine", marker = "implementation_name != 'pypy'", specifier = "~=2.9" },
-    { name = "timeout-decorator", specifier = "~=0.5" },
 ]
 docs = [
     { name = "furo", marker = "python_full_version >= '3.11'", specifier = "~=2025.7" },
@@ -2432,12 +2430,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/c2/bfe4b906a9fe0bf2d011534314212ed752d6b8f392c9c82f6ac63dccc5ab/time_machine-2.19.0-cp39-cp39-win_amd64.whl", hash = "sha256:011d7859089263204dc5fdf83dce7388f986fe833c9381d6106b4edfda2ebd3e", size = 17972, upload-time = "2025-08-19T17:22:06.026Z" },
     { url = "https://files.pythonhosted.org/packages/5d/73/182343eba05aa5787732aaa68f3b3feb5e40ddf86b928ae941be45646393/time_machine-2.19.0-cp39-cp39-win_arm64.whl", hash = "sha256:e1af66550fa4685434f00002808a525f176f1f92746646c0019bb86fbff48b27", size = 16820, upload-time = "2025-08-19T17:22:07.227Z" },
 ]
-
-[[package]]
-name = "timeout-decorator"
-version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/80/f8/0802dd14c58b5d3d72bb9caa4315535f58787a1dc50b81bbbcaaa15451be/timeout-decorator-0.5.0.tar.gz", hash = "sha256:6a2f2f58db1c5b24a2cc79de6345760377ad8bdc13813f5265f6c3e63d16b3d7", size = 4754, upload-time = "2020-11-15T00:53:06.506Z" }
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
The multiprocessing-based timeout method used by `timeout-decorator` now raises `PicklingError` on python 3.14 when used with pytest-xdist, so this change replaces it with a threading-based version.